### PR TITLE
refactor(client): lazy motion, drag-preview utility, and perf tweaks

### DIFF
--- a/packages/client/src/__tests__/components/ThreadView.test.tsx
+++ b/packages/client/src/__tests__/components/ThreadView.test.tsx
@@ -111,11 +111,13 @@ vi.mock('motion/react', () => {
         ([k]) => !['initial', 'animate', 'transition', 'exit', 'layout'].includes(k),
       ),
     );
+  const m = {
+    div: ({ children, ...props }: any) => <div {...filterMotionProps(props)}>{children}</div>,
+    span: ({ children, ...props }: any) => <span {...filterMotionProps(props)}>{children}</span>,
+  };
   return {
-    motion: {
-      div: ({ children, ...props }: any) => <div {...filterMotionProps(props)}>{children}</div>,
-      span: ({ children, ...props }: any) => <span {...filterMotionProps(props)}>{children}</span>,
-    },
+    m,
+    motion: m,
     AnimatePresence: ({ children }: any) => <>{children}</>,
     useReducedMotion: () => false,
   };

--- a/packages/client/src/components/D4CAnimation.tsx
+++ b/packages/client/src/components/D4CAnimation.tsx
@@ -1,4 +1,4 @@
-import { motion, AnimatePresence, useReducedMotion, type TargetAndTransition } from 'motion/react';
+import { m, AnimatePresence, useReducedMotion, type TargetAndTransition } from 'motion/react';
 import { useState, useEffect } from 'react';
 
 import { cn } from '@/lib/utils';
@@ -49,7 +49,7 @@ export function D4CAnimation({ size = 'default' }: { size?: 'default' | 'sm' }) 
       )}
     >
       <AnimatePresence mode="wait">
-        <motion.span
+        <m.span
           key={emoji + frame}
           initial={prefersReducedMotion ? false : anim.initial}
           animate={anim.animate}
@@ -58,7 +58,7 @@ export function D4CAnimation({ size = 'default' }: { size?: 'default' | 'sm' }) 
           className="inline-block"
         >
           {emoji}
-        </motion.span>
+        </m.span>
       </AnimatePresence>
     </span>
   );

--- a/packages/client/src/components/GitProgressModal.tsx
+++ b/packages/client/src/components/GitProgressModal.tsx
@@ -51,27 +51,26 @@ export function useStepTimers(steps: GitProgressStep[], open: boolean) {
   // Track status transitions — seed from persisted timestamps when available
   useEffect(() => {
     const now = Date.now();
+    const startMap = startTimes.current;
+    const endMap = endTimes.current;
     for (const step of steps) {
-      if (step.status === 'running' && !startTimes.current.has(step.id)) {
-        startTimes.current.set(step.id, step.startedAt ?? now);
-        endTimes.current.delete(step.id);
+      if (step.status === 'running' && !startMap.has(step.id)) {
+        startMap.set(step.id, step.startedAt ?? now);
+        endMap.delete(step.id);
       }
-      if (
-        (step.status === 'completed' || step.status === 'failed') &&
-        !endTimes.current.has(step.id)
-      ) {
+      if ((step.status === 'completed' || step.status === 'failed') && !endMap.has(step.id)) {
         // Seed both start and end from persisted timestamps if available
-        if (!startTimes.current.has(step.id) && step.startedAt) {
-          startTimes.current.set(step.id, step.startedAt);
+        if (!startMap.has(step.id) && step.startedAt) {
+          startMap.set(step.id, step.startedAt);
         }
-        if (startTimes.current.has(step.id)) {
-          endTimes.current.set(step.id, step.completedAt ?? now);
+        if (startMap.has(step.id)) {
+          endMap.set(step.id, step.completedAt ?? now);
         }
       }
       // If a step went back to pending (e.g. commit reset on hook failure), clear its timers
       if (step.status === 'pending') {
-        startTimes.current.delete(step.id);
-        endTimes.current.delete(step.id);
+        startMap.delete(step.id);
+        endMap.delete(step.id);
       }
     }
   }, [steps]);

--- a/packages/client/src/components/KanbanView.tsx
+++ b/packages/client/src/components/KanbanView.tsx
@@ -647,11 +647,24 @@ export function KanbanView({
     async (
       prompt: string,
       opts: {
+        provider?: string;
         model: string;
         mode: string;
+        effort?: string;
         threadMode?: string;
+        runtime?: string;
         baseBranch?: string;
         sendToBacklog?: boolean;
+        fileReferences?: { path: string; type?: 'file' | 'folder' }[];
+        symbolReferences?: {
+          path: string;
+          name: string;
+          kind: string;
+          line: number;
+          endLine?: number;
+        }[];
+        agentTemplateId?: string;
+        templateVariables?: Record<string, string>;
       },
       images?: any[],
     ): Promise<boolean> => {
@@ -695,13 +708,20 @@ export function KanbanView({
           projectId: slideUpProjectId,
           title: prompt.slice(0, 200),
           mode: threadMode,
+          runtime: opts.runtime as 'local' | 'remote' | undefined,
+          provider: opts.provider,
           model: opts.model,
           permissionMode: opts.mode,
+          effort: opts.effort,
           baseBranch: opts.baseBranch,
           prompt,
           images,
           allowedTools,
           disallowedTools,
+          fileReferences: opts.fileReferences,
+          symbolReferences: opts.symbolReferences,
+          agentTemplateId: opts.agentTemplateId,
+          templateVariables: opts.templateVariables,
         });
 
         if (result.isErr()) {

--- a/packages/client/src/components/LoginPage.tsx
+++ b/packages/client/src/components/LoginPage.tsx
@@ -30,7 +30,7 @@ export function LoginPage() {
     <div className="flex min-h-screen items-center justify-center bg-background">
       <div className="w-full max-w-sm space-y-6 rounded-lg border border-border bg-card p-8 shadow-lg">
         <div className="text-center">
-          <h1 className="text-2xl font-bold text-foreground">{t('app.title')}</h1>
+          <h1 className="text-2xl font-semibold text-foreground">{t('app.title')}</h1>
           <p className="mt-1 text-sm text-muted-foreground">{t('auth.signInPrompt')}</p>
         </div>
 

--- a/packages/client/src/components/MediaPreview.tsx
+++ b/packages/client/src/components/MediaPreview.tsx
@@ -230,7 +230,7 @@ function VideoPreview({
       src={src}
       data-testid="media-preview-video"
       onError={() => onError?.(new Error(`Failed to load video: ${src}`))}
-      className="max-h-[70vh] w-full bg-black"
+      className="max-h-[70vh] w-full bg-gray-950"
     >
       {name && <track kind="metadata" label={name} />}
       Your browser does not support the video element.

--- a/packages/client/src/components/PromptInputUI.stories.tsx
+++ b/packages/client/src/components/PromptInputUI.stories.tsx
@@ -280,7 +280,7 @@ function MinimalStory() {
   const [hasContent, setHasContent] = useState(false);
   const [submitted, setSubmitted] = useState<string | null>(null);
 
-  const handleChange = useCallback(() => {
+  const trackEditorContent = useCallback(() => {
     const text = (editorRef.current?.getText() ?? '').trim();
     setHasContent(text.length > 0);
   }, []);
@@ -305,7 +305,7 @@ function MinimalStory() {
             ref={editorRef}
             placeholder="Type instructions or feedback..."
             onSubmit={handleSubmit}
-            onChange={handleChange}
+            onChange={trackEditorContent}
             className="max-h-[120px] min-h-[40px] overflow-y-auto text-sm"
           />
         </div>

--- a/packages/client/src/components/ReviewPane.stories.tsx
+++ b/packages/client/src/components/ReviewPane.stories.tsx
@@ -452,7 +452,13 @@ function seedStores(
 
 // ── Wrapper ─────────────────────────────────────────────────
 
-function ReviewPaneWrapper({ mockFetchOpts = {} }: { mockFetchOpts?: MockFetchOptions }) {
+const EMPTY_MOCK_OPTS: MockFetchOptions = {};
+
+function ReviewPaneWrapper({
+  mockFetchOpts = EMPTY_MOCK_OPTS,
+}: {
+  mockFetchOpts?: MockFetchOptions;
+}) {
   // Install mock fetch synchronously BEFORE the first render so that
   // ReviewPane's mount effect (which fires before parent effects) hits
   // the mock instead of the real network — fixing "Failed to load changes".

--- a/packages/client/src/components/SearchablePicker.tsx
+++ b/packages/client/src/components/SearchablePicker.tsx
@@ -320,10 +320,11 @@ export function SearchablePicker({
 }
 
 const CREATE_NEW_BRANCH_KEY = '__create_new_branch__';
+const EMPTY_REMOTE_BRANCHES: string[] = [];
 
 export function BranchPicker({
   branches,
-  remoteBranches = [],
+  remoteBranches = EMPTY_REMOTE_BRANCHES,
   defaultBranch,
   selected,
   onChange,

--- a/packages/client/src/components/SetupWizard.tsx
+++ b/packages/client/src/components/SetupWizard.tsx
@@ -39,7 +39,7 @@ function WelcomeSlide({ onNext }: { onNext: () => void }) {
         <div className="flex items-center justify-center">
           <Terminal className="size-8 text-primary" />
         </div>
-        <h1 className="text-2xl font-bold text-foreground">Welcome to funny</h1>
+        <h1 className="text-2xl font-semibold text-foreground">Welcome to funny</h1>
         <p className="text-sm leading-relaxed text-muted-foreground">
           Orchestrate multiple Claude Code agents in parallel. Each agent works on its own git
           branch, so they never conflict.

--- a/packages/client/src/components/SlideUpPrompt.tsx
+++ b/packages/client/src/components/SlideUpPrompt.tsx
@@ -10,18 +10,33 @@ import {
 
 import { PromptInput } from './PromptInput';
 
+type SlideUpSubmitOpts = {
+  provider?: string;
+  model: string;
+  mode: string;
+  effort?: string;
+  threadMode?: string;
+  runtime?: string;
+  baseBranch?: string;
+  sendToBacklog?: boolean;
+  fileReferences?: { path: string; type?: 'file' | 'folder' }[];
+  symbolReferences?: {
+    path: string;
+    name: string;
+    kind: string;
+    line: number;
+    endLine?: number;
+  }[];
+  agentTemplateId?: string;
+  templateVariables?: Record<string, string>;
+};
+
 interface SlideUpPromptProps {
   open: boolean;
   onClose: () => void;
   onSubmit: (
     prompt: string,
-    opts: {
-      model: string;
-      mode: string;
-      threadMode?: string;
-      baseBranch?: string;
-      sendToBacklog?: boolean;
-    },
+    opts: SlideUpSubmitOpts,
     images?: any[],
   ) => Promise<boolean | void> | boolean | void;
   loading?: boolean;
@@ -39,13 +54,7 @@ export function SlideUpPrompt({
 
   const handleSubmit = async (
     prompt: string,
-    opts: {
-      model: string;
-      mode: string;
-      threadMode?: string;
-      baseBranch?: string;
-      sendToBacklog?: boolean;
-    },
+    opts: SlideUpSubmitOpts,
     images?: any[],
   ): Promise<boolean> => {
     const result = await onSubmit(prompt, opts, images);

--- a/packages/client/src/components/ThreadPickerDialog.tsx
+++ b/packages/client/src/components/ThreadPickerDialog.tsx
@@ -30,11 +30,13 @@ interface ThreadPickerDialogProps {
   excludeIds?: string[];
 }
 
+const EMPTY_EXCLUDE_IDS: string[] = [];
+
 export function ThreadPickerDialog({
   open,
   onOpenChange,
   onSelect,
-  excludeIds = [],
+  excludeIds = EMPTY_EXCLUDE_IDS,
 }: ThreadPickerDialogProps) {
   // Skip store subscriptions and all computation when the dialog is closed.
   // This avoids re-rendering on every threadsByProject update and prevents

--- a/packages/client/src/components/WorktreeSetupProgress.tsx
+++ b/packages/client/src/components/WorktreeSetupProgress.tsx
@@ -1,5 +1,5 @@
 import { Check, Circle, Loader2, X } from 'lucide-react';
-import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
+import { m, AnimatePresence, useReducedMotion } from 'motion/react';
 import { useMemo } from 'react';
 
 import {
@@ -51,7 +51,7 @@ export function WorktreeSetupProgress({ steps }: WorktreeSetupProgressProps) {
       {/* Focal step with animation */}
       <div className="flex min-h-[100px] w-full items-center justify-center">
         <AnimatePresence mode="wait">
-          <motion.div
+          <m.div
             key={focalStep.id + '-' + focalStep.status}
             initial={prefersReducedMotion ? false : { opacity: 0, y: 12, scale: 0.95 }}
             animate={{ opacity: 1, y: 0, scale: 1 }}
@@ -98,7 +98,7 @@ export function WorktreeSetupProgress({ steps }: WorktreeSetupProgressProps) {
                 {focalStep.error}
               </pre>
             )}
-          </motion.div>
+          </m.div>
         </AnimatePresence>
       </div>
 

--- a/packages/client/src/components/kanban/KanbanCard.tsx
+++ b/packages/client/src/components/kanban/KanbanCard.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { HighlightText, normalize } from '@/components/ui/highlight-text';
 import { api } from '@/lib/api';
+import { setDashedDragPreview } from '@/lib/drag-preview';
 import { statusConfig, timeAgo } from '@/lib/thread-utils';
 import { toastError } from '@/lib/toast-error';
 import { buildPath } from '@/lib/url';
@@ -83,6 +84,8 @@ export const KanbanCard = memo(function KanbanCard({
         sourceStage: thread.archived ? 'archived' : thread.stage || 'backlog',
         projectId: thread.projectId,
       }),
+      onGenerateDragPreview: ({ nativeSetDragImage }) =>
+        setDashedDragPreview({ nativeSetDragImage, source: el }),
       onDragStart: () => setIsDragging(true),
       onDrop: () => setIsDragging(false),
     });

--- a/packages/client/src/components/live-columns/ThreadColumn.tsx
+++ b/packages/client/src/components/live-columns/ThreadColumn.tsx
@@ -1,5 +1,4 @@
 import { draggable } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
-import { setCustomNativeDragPreview } from '@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview';
 import { Loader2, X, GripVertical } from 'lucide-react';
 import { useReducedMotion } from 'motion/react';
 import { memo, startTransition, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -12,6 +11,7 @@ import { MessageStream, type MessageStreamHandle } from '@/components/thread/Mes
 import { ProjectHeader } from '@/components/thread/ProjectHeader';
 import { TooltipIconButton } from '@/components/ui/tooltip-icon-button';
 import { api } from '@/lib/api';
+import { setDashedDragPreview } from '@/lib/drag-preview';
 import { statusConfig } from '@/lib/thread-utils';
 import { cn } from '@/lib/utils';
 import { useAppStore } from '@/stores/app-store';
@@ -87,24 +87,8 @@ export const ThreadColumn = memo(function ThreadColumn({
         type: 'grid-thread',
         threadId,
       }),
-      onGenerateDragPreview: ({ nativeSetDragImage }) => {
-        setCustomNativeDragPreview({
-          nativeSetDragImage,
-          getOffset: () => ({ x: 16, y: 16 }),
-          render: ({ container }) => {
-            const rect = el.getBoundingClientRect();
-            const preview = document.createElement('div');
-            preview.style.cssText = [
-              `width:${rect.width}px`,
-              `height:${rect.height}px`,
-              'border-radius:8px',
-              'border:2px dashed hsl(var(--primary))',
-              'background:hsl(var(--primary) / 0.05)',
-            ].join(';');
-            container.appendChild(preview);
-          },
-        });
-      },
+      onGenerateDragPreview: ({ nativeSetDragImage }) =>
+        setDashedDragPreview({ nativeSetDragImage, source: el }),
       onDragStart: () => setIsDragging(true),
       onDrop: () => setIsDragging(false),
     });

--- a/packages/client/src/components/settings/AgentTemplateSettings.tsx
+++ b/packages/client/src/components/settings/AgentTemplateSettings.tsx
@@ -383,7 +383,7 @@ function TemplateEditor({
             onClick={onClose}
             data-testid="agent-template-editor-close"
           >
-            Done
+            Close editor
           </Button>
         </div>
       </div>

--- a/packages/client/src/components/sidebar/ProjectItem.tsx
+++ b/packages/client/src/components/sidebar/ProjectItem.tsx
@@ -37,6 +37,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useStableNavigate } from '@/hooks/use-stable-navigate';
 import { api } from '@/lib/api';
+import { setDashedDragPreview } from '@/lib/drag-preview';
 import { openDirectoryInEditor, getEditorLabel } from '@/lib/editor-utils';
 import { buildPath } from '@/lib/url';
 import { cn } from '@/lib/utils';
@@ -91,6 +92,8 @@ const ProjectThreadItem: FC<ProjectThreadItemProps> = memo(function ProjectThrea
         threadId: thread.id,
         projectId,
       }),
+      onGenerateDragPreview: ({ nativeSetDragImage }) =>
+        setDashedDragPreview({ nativeSetDragImage, source: el }),
       onDragStart: () => setIsDragging(true),
       onDrop: () => setIsDragging(false),
     });

--- a/packages/client/src/components/sidebar/RecentThreads.tsx
+++ b/packages/client/src/components/sidebar/RecentThreads.tsx
@@ -16,7 +16,7 @@ import { ThreadGroup } from './ThreadGroup';
 import { ThreadItem } from './ThreadItem';
 import { ViewAllButton } from './ViewAllButton';
 
-const FINISHED_STATUSES: ThreadStatus[] = ['completed', 'failed', 'stopped', 'interrupted'];
+const FINISHED_STATUSES = new Set<ThreadStatus>(['completed', 'failed', 'stopped', 'interrupted']);
 
 interface FinishedThread extends Thread {
   projectName: string;
@@ -55,11 +55,7 @@ export function RecentThreads({
 
     for (const [projectId, threads] of Object.entries(threadsByProject)) {
       for (const thread of threads) {
-        if (
-          FINISHED_STATUSES.includes(thread.status) &&
-          !thread.archived &&
-          thread.stage !== 'done'
-        ) {
+        if (FINISHED_STATUSES.has(thread.status) && !thread.archived && thread.stage !== 'done') {
           const project = projectMap.get(projectId);
           result.push({
             ...thread,

--- a/packages/client/src/components/sidebar/ThreadList.tsx
+++ b/packages/client/src/components/sidebar/ThreadList.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from 'react-i18next';
 import { useBranchSwitch } from '@/hooks/use-branch-switch';
 import { useMinuteTick } from '@/hooks/use-minute-tick';
 import { useStableNavigate } from '@/hooks/use-stable-navigate';
+import { setDashedDragPreview } from '@/lib/drag-preview';
 import { threadsVisuallyEqual } from '@/lib/shallow-compare';
 import { timeAgo } from '@/lib/thread-utils';
 import { buildPath } from '@/lib/url';
@@ -316,6 +317,8 @@ const ThreadListItem = memo(function ThreadListItem({
         threadId: thread.id,
         projectId: thread.projectId,
       }),
+      onGenerateDragPreview: ({ nativeSetDragImage }) =>
+        setDashedDragPreview({ nativeSetDragImage, source: el }),
       onDragStart: () => setIsDragging(true),
       onDrop: () => setIsDragging(false),
     });

--- a/packages/client/src/components/test-runner/TestDetailTabs.tsx
+++ b/packages/client/src/components/test-runner/TestDetailTabs.tsx
@@ -881,6 +881,18 @@ function SourceTab({
 // ─── Tab: Call ─────────────────────────────────────────────
 
 /** Regex to match Playwright action lines from --reporter=line output */
+const PLAYWRIGHT_SNIPPETS = [
+  'page.goto',
+  'page.click',
+  'page.fill',
+  'page.type',
+  'page.press',
+  'page.waitFor',
+  'locator.',
+  'expect(',
+  'navigating to',
+  'waiting for',
+];
 const ACTION_PATTERN =
   /^(\s*)(\d+\s+\|)?\s*(page\.|locator\.|expect\(|await\s+(?:page|locator|expect))/;
 const STEP_PATTERN = /^(\s*)(›|→|⮕|➤|\d+\))\s+(.+)/;
@@ -914,16 +926,7 @@ function CallTab({
       if (
         ACTION_PATTERN.test(text) ||
         STEP_PATTERN.test(text) ||
-        text.includes('page.goto') ||
-        text.includes('page.click') ||
-        text.includes('page.fill') ||
-        text.includes('page.type') ||
-        text.includes('page.press') ||
-        text.includes('page.waitFor') ||
-        text.includes('locator.') ||
-        text.includes('expect(') ||
-        text.includes('navigating to') ||
-        text.includes('waiting for') ||
+        PLAYWRIGHT_SNIPPETS.some((s) => text.includes(s)) ||
         /^\s*\d+\s*\|/.test(text)
       ) {
         result.push({

--- a/packages/client/src/components/thread/MessageStream.tsx
+++ b/packages/client/src/components/thread/MessageStream.tsx
@@ -1,6 +1,6 @@
 import type { ThreadEvent, WaitingReason } from '@funny/shared';
 import { Loader2, ArrowDown, Clock } from 'lucide-react';
-import { motion, useReducedMotion } from 'motion/react';
+import { m, useReducedMotion } from 'motion/react';
 import {
   useState,
   useRef,
@@ -550,7 +550,7 @@ export const MessageStream = forwardRef<MessageStreamHandle, MessageStreamProps>
 
           {/* Running indicator */}
           {isRunning && !isExternal && (
-            <motion.div
+            <m.div
               initial={prefersReducedMotion ? false : { opacity: 0, y: 8 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.3, ease: 'easeOut' }}
@@ -558,11 +558,11 @@ export const MessageStream = forwardRef<MessageStreamHandle, MessageStreamProps>
             >
               <D4CAnimation size={compact ? 'sm' : undefined} />
               <span className="text-xs">{t('thread.agentWorking')}</span>
-            </motion.div>
+            </m.div>
           )}
 
           {isRunning && isExternal && (
-            <motion.div
+            <m.div
               initial={prefersReducedMotion ? false : { opacity: 0, y: 8 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.3, ease: 'easeOut' }}
@@ -576,12 +576,12 @@ export const MessageStream = forwardRef<MessageStreamHandle, MessageStreamProps>
               <span className="text-xs">
                 {t('thread.runningExternally', 'Running externally\u2026')}
               </span>
-            </motion.div>
+            </m.div>
           )}
 
           {/* Waiting: question */}
           {status === 'waiting' && waitingReason === 'question' && (
-            <motion.div
+            <m.div
               initial={prefersReducedMotion ? false : { opacity: 0, y: 6 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.25, ease: 'easeOut' }}
@@ -589,12 +589,12 @@ export const MessageStream = forwardRef<MessageStreamHandle, MessageStreamProps>
             >
               <Clock className="size-3.5 animate-pulse text-yellow-400" />
               {t('thread.waitingForResponse')}
-            </motion.div>
+            </m.div>
           )}
 
           {/* Waiting: permission */}
           {status === 'waiting' && waitingReason === 'permission' && pendingPermission && (
-            <motion.div
+            <m.div
               initial={prefersReducedMotion ? false : { opacity: 0, y: 6 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.25, ease: 'easeOut' }}
@@ -606,23 +606,23 @@ export const MessageStream = forwardRef<MessageStreamHandle, MessageStreamProps>
                 onAlwaysAllow={handlePermissionAlwaysAllow}
                 onDeny={handlePermissionDeny}
               />
-            </motion.div>
+            </m.div>
           )}
 
           {/* Waiting: no specific reason */}
           {status === 'waiting' && !waitingReason && (
-            <motion.div
+            <m.div
               initial={prefersReducedMotion ? false : { opacity: 0, y: 6 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.25, ease: 'easeOut' }}
             >
               <WaitingActions onSend={(text) => onSend(text, { model, mode: permissionMode })} />
-            </motion.div>
+            </m.div>
           )}
 
           {/* Result card */}
           {resultInfo && !isRunning && status !== 'stopped' && status !== 'interrupted' && (
-            <motion.div
+            <m.div
               initial={prefersReducedMotion ? false : { opacity: 0, y: 6 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.3, ease: 'easeOut' }}
@@ -638,12 +638,12 @@ export const MessageStream = forwardRef<MessageStreamHandle, MessageStreamProps>
                     : undefined
                 }
               />
-            </motion.div>
+            </m.div>
           )}
 
           {/* Interrupted card */}
           {status === 'interrupted' && (
-            <motion.div
+            <m.div
               initial={prefersReducedMotion ? false : { opacity: 0, y: 6 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.3, ease: 'easeOut' }}
@@ -651,12 +651,12 @@ export const MessageStream = forwardRef<MessageStreamHandle, MessageStreamProps>
               <AgentInterruptedCard
                 onContinue={() => onSend('Continue', { model, mode: permissionMode })}
               />
-            </motion.div>
+            </m.div>
           )}
 
           {/* Stopped card */}
           {status === 'stopped' && (
-            <motion.div
+            <m.div
               initial={prefersReducedMotion ? false : { opacity: 0, y: 6 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.3, ease: 'easeOut' }}
@@ -664,7 +664,7 @@ export const MessageStream = forwardRef<MessageStreamHandle, MessageStreamProps>
               <AgentStoppedCard
                 onContinue={() => onSend('Continue', { model, mode: permissionMode })}
               />
-            </motion.div>
+            </m.div>
           )}
 
           {/* Prompt pin spacer (full mode only) */}

--- a/packages/client/src/components/thread/TodoPanel.tsx
+++ b/packages/client/src/components/thread/TodoPanel.tsx
@@ -1,5 +1,5 @@
 import { ListTodo, X, ChevronDown, ChevronUp, Circle, CircleDot, CircleCheck } from 'lucide-react';
-import { motion } from 'motion/react';
+import { m } from 'motion/react';
 import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -38,7 +38,7 @@ export function TodoPanel({ todos, progress, onDismiss }: TodoPanelProps) {
   }, [scrollTargetIdx, minimized, todos]);
 
   return (
-    <motion.div
+    <m.div
       initial={{ opacity: 0, x: 20 }}
       animate={{ opacity: 1, x: 0 }}
       exit={{ opacity: 0, x: 20 }}
@@ -49,7 +49,7 @@ export function TodoPanel({ todos, progress, onDismiss }: TodoPanelProps) {
       <div className="flex items-center gap-2 border-b border-border/50 px-3 py-2">
         <ListTodo className="icon-sm text-muted-foreground" />
         <span className="flex-1 text-xs font-medium">{t('todoPanel.title')}</span>
-        <motion.span
+        <m.span
           key={`${progress.completed}/${progress.total}`}
           initial={{ scale: 1.2 }}
           animate={{ scale: 1 }}
@@ -62,7 +62,7 @@ export function TodoPanel({ todos, progress, onDismiss }: TodoPanelProps) {
           )}
         >
           {progress.completed}/{progress.total}
-        </motion.span>
+        </m.span>
         <Tooltip>
           <TooltipTrigger asChild>
             <button
@@ -96,7 +96,7 @@ export function TodoPanel({ todos, progress, onDismiss }: TodoPanelProps) {
           {/* Progress bar */}
           <div className="px-3 pt-2">
             <div className="h-1 overflow-hidden rounded-full bg-muted">
-              <motion.div
+              <m.div
                 className={cn(
                   'h-full rounded-full',
                   allDone ? 'bg-status-success/80' : 'bg-status-info/80',
@@ -112,14 +112,14 @@ export function TodoPanel({ todos, progress, onDismiss }: TodoPanelProps) {
           <ScrollArea viewportRef={listRef} className="max-h-64">
             <div className="space-y-1 px-3 py-1 pb-2">
               {todos.map((todo, i) => (
-                <motion.div
+                <m.div
                   key={todo.content}
                   className="flex items-start gap-2"
                   initial={{ opacity: 0, x: -8 }}
                   animate={{ opacity: 1, x: 0 }}
                   transition={{ duration: 0.2, delay: i * 0.03 }}
                 >
-                  <motion.div
+                  <m.div
                     className="mt-0.5 flex-shrink-0"
                     key={`${todo.content}-${todo.status}`}
                     initial={{ scale: 0.5, opacity: 0 }}
@@ -133,7 +133,7 @@ export function TodoPanel({ todos, progress, onDismiss }: TodoPanelProps) {
                     ) : (
                       <Circle className="icon-sm text-muted-foreground/50" />
                     )}
-                  </motion.div>
+                  </m.div>
                   <span
                     className={cn(
                       'text-xs leading-relaxed transition-all duration-300',
@@ -144,12 +144,12 @@ export function TodoPanel({ todos, progress, onDismiss }: TodoPanelProps) {
                   >
                     {todo.content}
                   </span>
-                </motion.div>
+                </m.div>
               ))}
             </div>
           </ScrollArea>
         </>
       )}
-    </motion.div>
+    </m.div>
   );
 }

--- a/packages/client/src/components/thread/UserMessageCard.stories.tsx
+++ b/packages/client/src/components/thread/UserMessageCard.stories.tsx
@@ -142,6 +142,18 @@ export const WithSlashCommand: Story = {
   },
 };
 
+/** Filesystem paths must NOT render as slash-command chips. */
+export const WithFilesystemPath: Story = {
+  args: {
+    content:
+      'puedes procesar todas las facturas de cloudflare en /home/argenisleon/Downloads/cloudflare y crear un excel',
+    model: 'opus',
+    permissionMode: 'autoEdit',
+    timestamp: new Date().toISOString(),
+    onClick: fn(),
+  },
+};
+
 /** Code snippet in the prompt. */
 export const WithCodeSnippet: Story = {
   args: {

--- a/packages/client/src/components/thread/UserMessageCard.tsx
+++ b/packages/client/src/components/thread/UserMessageCard.tsx
@@ -101,9 +101,11 @@ function renderInlineContent(text: string, fileMap: Map<string, ReferencedItem>)
   // Build combined regex: slash commands (at start) + @path mentions
   const regexParts: string[] = [];
 
-  // Slash command: /name at start of text or after whitespace
+  // Slash command: /name at start of text or after whitespace, not adjacent to
+  // any path-continuation char (so /home/user/... isn't mistaken for a command,
+  // and the regex can't backtrack to /hom + "e/..." either).
   // Match /word characters, colons, dots, hyphens (e.g. /skill-creator:skill-creator)
-  regexParts.push('(?<=^|\\s)\\/([\\w:.-]+)');
+  regexParts.push('(?<=^|\\s)\\/([\\w:.-]+)(?![\\w/:.-])');
 
   // @path mentions
   if (fileMap.size > 0) {

--- a/packages/client/src/components/tool-cards/AnnotatableContent.stories.tsx
+++ b/packages/client/src/components/tool-cards/AnnotatableContent.stories.tsx
@@ -5,13 +5,15 @@ import '@/i18n/config';
 import { AnnotatableContent } from './AnnotatableContent';
 import type { PlanComment } from './PlanReviewDialog';
 
+const EMPTY_COMMENTS: PlanComment[] = [];
+
 /* -------------------------------------------------------------------------- */
 /*  Interactive wrapper                                                        */
 /* -------------------------------------------------------------------------- */
 
 function InteractiveWrapper({
   children,
-  initialComments = [],
+  initialComments = EMPTY_COMMENTS,
 }: {
   children: React.ReactNode;
   initialComments?: PlanComment[];

--- a/packages/client/src/components/tool-cards/AnnotatableContent.tsx
+++ b/packages/client/src/components/tool-cards/AnnotatableContent.tsx
@@ -16,6 +16,8 @@ import {
  *
  * Used by both the inline ExitPlanModeCard and the PlanReviewDialog.
  */
+const EMPTY_DEPS: unknown[] = [];
+
 export function AnnotatableContent({
   children,
   planComments,
@@ -25,7 +27,7 @@ export function AnnotatableContent({
   className,
   active = true,
   /** Extra deps that should trigger re-highlighting (e.g. dialog `open` state) */
-  highlightDeps = [],
+  highlightDeps = EMPTY_DEPS,
   /** Delay before applying highlights (useful for dialog mount) */
   highlightDelay = 0,
 }: {

--- a/packages/client/src/components/tool-cards/AskQuestionCard.tsx
+++ b/packages/client/src/components/tool-cards/AskQuestionCard.tsx
@@ -9,7 +9,7 @@ import {
   MicOff,
   Loader2,
 } from 'lucide-react';
-import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
+import { AnimatePresence, m, useReducedMotion } from 'motion/react';
 import { useState, useRef, useEffect, useMemo, useCallback, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
@@ -402,7 +402,7 @@ export const AskQuestionCard = memo(function AskQuestionCard({
             {/* Active question — vertical slide between tabs */}
             <div className="relative overflow-hidden">
               <AnimatePresence mode="wait" initial={false} custom={slideDirection}>
-                <motion.div
+                <m.div
                   key={activeTab}
                   custom={slideDirection}
                   variants={{
@@ -634,7 +634,7 @@ export const AskQuestionCard = memo(function AskQuestionCard({
                       </button>
                     </div>
                   )}
-                </motion.div>
+                </m.div>
               </AnimatePresence>
             </div>
           </>

--- a/packages/client/src/components/ui/alert-dialog.tsx
+++ b/packages/client/src/components/ui/alert-dialog.tsx
@@ -10,39 +10,45 @@ const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
 
 const AlertDialogPortal = AlertDialogPrimitive.Portal;
 
-const AlertDialogOverlay = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Overlay
-    className={cn(
-      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-      className,
-    )}
-    {...props}
-    ref={ref}
-  />
-));
-AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
-
-const AlertDialogContent = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <AlertDialogPortal>
-    <AlertDialogOverlay />
-    <AlertDialogPrimitive.Content
-      ref={ref}
+function AlertDialogOverlay({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay> & {
+  ref?: React.Ref<React.ElementRef<typeof AlertDialogPrimitive.Overlay>>;
+}) {
+  return (
+    <AlertDialogPrimitive.Overlay
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
         className,
       )}
       {...props}
+      ref={ref}
     />
-  </AlertDialogPortal>
-));
-AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
-
+  );
+}
+function AlertDialogContent({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content> & {
+  ref?: React.Ref<React.ElementRef<typeof AlertDialogPrimitive.Content>>;
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
 const AlertDialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
 );
@@ -56,50 +62,62 @@ const AlertDialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDiv
 );
 AlertDialogFooter.displayName = 'AlertDialogFooter';
 
-const AlertDialogTitle = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
->(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Title
-    ref={ref}
-    className={cn('text-lg font-semibold', className)}
-    {...props}
-  />
-));
-AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
-
-const AlertDialogDescription = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
->(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Description
-    ref={ref}
-    className={cn('text-sm text-muted-foreground', className)}
-    {...props}
-  />
-));
-AlertDialogDescription.displayName = AlertDialogPrimitive.Description.displayName;
-
-const AlertDialogAction = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Action>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
->(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Action ref={ref} className={cn(buttonVariants(), className)} {...props} />
-));
-AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
-
-const AlertDialogCancel = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
->(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Cancel
-    ref={ref}
-    className={cn(buttonVariants({ variant: 'outline' }), 'mt-2 sm:mt-0', className)}
-    {...props}
-  />
-));
-AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
-
+function AlertDialogTitle({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title> & {
+  ref?: React.Ref<React.ElementRef<typeof AlertDialogPrimitive.Title>>;
+}) {
+  return (
+    <AlertDialogPrimitive.Title
+      ref={ref}
+      className={cn('text-lg font-semibold', className)}
+      {...props}
+    />
+  );
+}
+function AlertDialogDescription({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description> & {
+  ref?: React.Ref<React.ElementRef<typeof AlertDialogPrimitive.Description>>;
+}) {
+  return (
+    <AlertDialogPrimitive.Description
+      ref={ref}
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+function AlertDialogAction({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action> & {
+  ref?: React.Ref<React.ElementRef<typeof AlertDialogPrimitive.Action>>;
+}) {
+  return (
+    <AlertDialogPrimitive.Action ref={ref} className={cn(buttonVariants(), className)} {...props} />
+  );
+}
+function AlertDialogCancel({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel> & {
+  ref?: React.Ref<React.ElementRef<typeof AlertDialogPrimitive.Cancel>>;
+}) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      ref={ref}
+      className={cn(buttonVariants({ variant: 'outline' }), 'mt-2 sm:mt-0', className)}
+      {...props}
+    />
+  );
+}
 export {
   AlertDialog,
   AlertDialogPortal,

--- a/packages/client/src/components/ui/alert.tsx
+++ b/packages/client/src/components/ui/alert.tsx
@@ -19,31 +19,35 @@ const alertVariants = cva(
   },
 );
 
-const Alert = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
->(({ className, variant, ...props }, ref) => (
-  <div ref={ref} role="alert" className={cn(alertVariants({ variant }), className)} {...props} />
-));
-Alert.displayName = 'Alert';
-
-const AlertTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => (
+function Alert({
+  className,
+  variant,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof alertVariants> & { ref?: React.Ref<HTMLDivElement> }) {
+  return (
+    <div ref={ref} role="alert" className={cn(alertVariants({ variant }), className)} {...props} />
+  );
+}
+function AlertTitle({
+  className,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLHeadingElement> & { ref?: React.Ref<HTMLParagraphElement> }) {
+  return (
     <h5
       ref={ref}
       className={cn('mb-1 font-medium leading-none tracking-tight', className)}
       {...props}
     />
-  ),
-);
-AlertTitle.displayName = 'AlertTitle';
-
-const AlertDescription = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
->(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn('text-sm [&_p]:leading-relaxed', className)} {...props} />
-));
-AlertDescription.displayName = 'AlertDescription';
-
+  );
+}
+function AlertDescription({
+  className,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLParagraphElement> & { ref?: React.Ref<HTMLParagraphElement> }) {
+  return <div ref={ref} className={cn('text-sm [&_p]:leading-relaxed', className)} {...props} />;
+}
 export { Alert, AlertTitle, AlertDescription };

--- a/packages/client/src/components/ui/avatar.tsx
+++ b/packages/client/src/components/ui/avatar.tsx
@@ -79,54 +79,71 @@ const avatarVariants = cva('relative flex shrink-0 overflow-hidden rounded-full'
   },
 });
 
-const Avatar = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root> & VariantProps<typeof avatarVariants>
->(({ className, size, ...props }, ref) => (
-  <AvatarPrimitive.Root ref={ref} className={cn(avatarVariants({ size }), className)} {...props} />
-));
-Avatar.displayName = AvatarPrimitive.Root.displayName;
-
-const AvatarImage = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimitive.Image>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
->(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Image
-    ref={ref}
-    className={cn('aspect-square h-full w-full', className)}
-    {...props}
-  />
-));
-AvatarImage.displayName = AvatarPrimitive.Image.displayName;
-
-const AvatarFallback = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimitive.Fallback>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback> & { name?: string }
->(({ className, name, style, ...props }, ref) => (
-  <AvatarPrimitive.Fallback
-    ref={ref}
-    className={cn(
-      'flex h-full w-full items-center justify-center rounded-full',
-      !name && 'bg-muted',
-      className,
-    )}
-    style={
-      name
-        ? (() => {
-            const hue = stringToHue(name);
-            const s = 0.6,
-              l = 0.8;
-            return {
-              backgroundColor: `hsl(${hue}, ${s * 100}%, ${l * 100}%)`,
-              color: contrastingTextColor(hue, s, l),
-              ...style,
-            };
-          })()
-        : style
-    }
-    {...props}
-  />
-));
-AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
-
+function Avatar({
+  className,
+  size,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root> &
+  VariantProps<typeof avatarVariants> & {
+    ref?: React.Ref<React.ElementRef<typeof AvatarPrimitive.Root>>;
+  }) {
+  return (
+    <AvatarPrimitive.Root
+      ref={ref}
+      className={cn(avatarVariants({ size }), className)}
+      {...props}
+    />
+  );
+}
+function AvatarImage({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image> & {
+  ref?: React.Ref<React.ElementRef<typeof AvatarPrimitive.Image>>;
+}) {
+  return (
+    <AvatarPrimitive.Image
+      ref={ref}
+      className={cn('aspect-square h-full w-full', className)}
+      {...props}
+    />
+  );
+}
+function AvatarFallback({
+  className,
+  name,
+  style,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback> & { name?: string } & {
+  ref?: React.Ref<React.ElementRef<typeof AvatarPrimitive.Fallback>>;
+}) {
+  return (
+    <AvatarPrimitive.Fallback
+      ref={ref}
+      className={cn(
+        'flex h-full w-full items-center justify-center rounded-full',
+        !name && 'bg-muted',
+        className,
+      )}
+      style={
+        name
+          ? (() => {
+              const hue = stringToHue(name);
+              const s = 0.6,
+                l = 0.8;
+              return {
+                backgroundColor: `hsl(${hue}, ${s * 100}%, ${l * 100}%)`,
+                color: contrastingTextColor(hue, s, l),
+                ...style,
+              };
+            })()
+          : style
+      }
+      {...props}
+    />
+  );
+}
 export { Avatar, AvatarImage, AvatarFallback };

--- a/packages/client/src/components/ui/breadcrumb.tsx
+++ b/packages/client/src/components/ui/breadcrumb.tsx
@@ -4,14 +4,20 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
-const Breadcrumb = React.forwardRef<
-  HTMLElement,
-  React.ComponentPropsWithoutRef<'nav'> & { separator?: React.ReactNode }
->(({ ...props }, ref) => <nav ref={ref} aria-label="breadcrumb" {...props} />);
-Breadcrumb.displayName = 'Breadcrumb';
-
-const BreadcrumbList = React.forwardRef<HTMLOListElement, React.ComponentPropsWithoutRef<'ol'>>(
-  ({ className, ...props }, ref) => (
+function Breadcrumb({
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<'nav'> & { separator?: React.ReactNode } & {
+  ref?: React.Ref<HTMLElement>;
+}) {
+  return <nav ref={ref} aria-label="breadcrumb" {...props} />;
+}
+function BreadcrumbList({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<'ol'> & { ref?: React.Ref<HTMLOListElement> }) {
+  return (
     <ol
       ref={ref}
       className={cn(
@@ -20,25 +26,29 @@ const BreadcrumbList = React.forwardRef<HTMLOListElement, React.ComponentPropsWi
       )}
       {...props}
     />
-  ),
-);
-BreadcrumbList.displayName = 'BreadcrumbList';
-
-const BreadcrumbItem = React.forwardRef<HTMLLIElement, React.ComponentPropsWithoutRef<'li'>>(
-  ({ className, ...props }, ref) => (
+  );
+}
+function BreadcrumbItem({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<'li'> & { ref?: React.Ref<HTMLLIElement> }) {
+  return (
     <li
       ref={ref}
       className={cn('inline-flex items-center gap-1.5 min-w-0', className)}
       {...props}
     />
-  ),
-);
-BreadcrumbItem.displayName = 'BreadcrumbItem';
-
-const BreadcrumbLink = React.forwardRef<
-  HTMLAnchorElement,
-  React.ComponentPropsWithoutRef<'a'> & { asChild?: boolean }
->(({ asChild, className, ...props }, ref) => {
+  );
+}
+function BreadcrumbLink({
+  asChild,
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<'a'> & { asChild?: boolean } & {
+  ref?: React.Ref<HTMLAnchorElement>;
+}) {
   const Comp = asChild ? Slot : 'a';
   return (
     <Comp
@@ -47,11 +57,13 @@ const BreadcrumbLink = React.forwardRef<
       {...props}
     />
   );
-});
-BreadcrumbLink.displayName = 'BreadcrumbLink';
-
-const BreadcrumbPage = React.forwardRef<HTMLSpanElement, React.ComponentPropsWithoutRef<'span'>>(
-  ({ className, ...props }, ref) => (
+}
+function BreadcrumbPage({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<'span'> & { ref?: React.Ref<HTMLSpanElement> }) {
+  return (
     <span
       ref={ref}
       role="link"
@@ -60,10 +72,8 @@ const BreadcrumbPage = React.forwardRef<HTMLSpanElement, React.ComponentPropsWit
       className={cn('font-medium text-foreground', className)}
       {...props}
     />
-  ),
-);
-BreadcrumbPage.displayName = 'BreadcrumbPage';
-
+  );
+}
 const BreadcrumbSeparator = ({ children, className, ...props }: React.ComponentProps<'li'>) => (
   <li
     role="presentation"

--- a/packages/client/src/components/ui/button.tsx
+++ b/packages/client/src/components/ui/button.tsx
@@ -40,31 +40,34 @@ export interface ButtonProps
   loading?: boolean;
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (
-    { className, variant, size, asChild = false, loading = false, children, disabled, ...props },
-    ref,
-  ) => {
-    const Comp = asChild ? Slot : 'button';
-    return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
-        disabled={disabled || loading}
-        {...props}
-      >
-        {asChild ? (
-          children
-        ) : (
-          <>
-            {loading && <Loader2 className="size-4 animate-spin" />}
-            {children}
-          </>
-        )}
-      </Comp>
-    );
-  },
-);
-Button.displayName = 'Button';
-
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  loading = false,
+  children,
+  disabled,
+  ref,
+  ...props
+}: ButtonProps & { ref?: React.Ref<HTMLButtonElement> }) {
+  const Comp = asChild ? Slot : 'button';
+  return (
+    <Comp
+      className={cn(buttonVariants({ variant, size, className }))}
+      ref={ref}
+      disabled={disabled || loading}
+      {...props}
+    >
+      {asChild ? (
+        children
+      ) : (
+        <>
+          {loading && <Loader2 className="size-4 animate-spin" />}
+          {children}
+        </>
+      )}
+    </Comp>
+  );
+}
 export { Button, buttonVariants };

--- a/packages/client/src/components/ui/checkbox.tsx
+++ b/packages/client/src/components/ui/checkbox.tsx
@@ -4,23 +4,26 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
-const Checkbox = React.forwardRef<
-  React.ElementRef<typeof CheckboxPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <CheckboxPrimitive.Root
-    ref={ref}
-    className={cn(
-      'peer size-3.5 shrink-0 rounded-[4px] border border-input shadow-xs outline-none transition-shadow focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:data-[state=checked]:bg-primary',
-      className,
-    )}
-    {...props}
-  >
-    <CheckboxPrimitive.Indicator className="grid place-content-center text-current transition-none">
-      <CheckIcon className="size-3" />
-    </CheckboxPrimitive.Indicator>
-  </CheckboxPrimitive.Root>
-));
-Checkbox.displayName = CheckboxPrimitive.Root.displayName;
-
+function Checkbox({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root> & {
+  ref?: React.Ref<React.ElementRef<typeof CheckboxPrimitive.Root>>;
+}) {
+  return (
+    <CheckboxPrimitive.Root
+      ref={ref}
+      className={cn(
+        'peer size-3.5 shrink-0 rounded-[4px] border border-input shadow-xs outline-none transition-shadow focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:data-[state=checked]:bg-primary',
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator className="grid place-content-center text-current transition-none">
+        <CheckIcon className="size-3" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
 export { Checkbox };

--- a/packages/client/src/components/ui/color-picker.tsx
+++ b/packages/client/src/components/ui/color-picker.tsx
@@ -9,6 +9,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useEffectEvent,
   useMemo,
   useRef,
   useState,
@@ -146,35 +147,30 @@ export const ColorPickerSelection = memo(({ className, ...props }: ColorPickerSe
             hsl(${hue}, 100%, 50%)`;
   }, [hue]);
 
-  const handlePointerMove = useCallback(
-    (event: PointerEvent) => {
-      if (!(isDragging && containerRef.current)) {
-        return;
-      }
-      const rect = containerRef.current.getBoundingClientRect();
-      const x = Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width));
-      const y = Math.max(0, Math.min(1, (event.clientY - rect.top) / rect.height));
-      setPositionX(x);
-      setPositionY(y);
-      setSaturation(x * 100);
-      const topLightness = x < 0.01 ? 100 : 50 + 50 * (1 - x);
-      const lightness = topLightness * (1 - y);
-      setLightness(lightness);
-    },
-    [isDragging, setSaturation, setLightness],
-  );
+  const onPointerMoveEvent = useEffectEvent((event: PointerEvent) => {
+    if (!containerRef.current) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    const x = Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width));
+    const y = Math.max(0, Math.min(1, (event.clientY - rect.top) / rect.height));
+    setPositionX(x);
+    setPositionY(y);
+    setSaturation(x * 100);
+    const topLightness = x < 0.01 ? 100 : 50 + 50 * (1 - x);
+    const lightness = topLightness * (1 - y);
+    setLightness(lightness);
+  });
 
   useEffect(() => {
+    if (!isDragging) return;
+    const handlePointerMove = (e: PointerEvent) => onPointerMoveEvent(e);
     const handlePointerUp = () => setIsDragging(false);
-    if (isDragging) {
-      window.addEventListener('pointermove', handlePointerMove);
-      window.addEventListener('pointerup', handlePointerUp);
-    }
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
     return () => {
       window.removeEventListener('pointermove', handlePointerMove);
       window.removeEventListener('pointerup', handlePointerUp);
     };
-  }, [isDragging, handlePointerMove]);
+  }, [isDragging]);
 
   return (
     <div
@@ -182,7 +178,7 @@ export const ColorPickerSelection = memo(({ className, ...props }: ColorPickerSe
       onPointerDown={(e) => {
         e.preventDefault();
         setIsDragging(true);
-        handlePointerMove(e.nativeEvent);
+        onPointerMoveEvent(e.nativeEvent);
       }}
       ref={containerRef}
       style={{ background: backgroundGradient }}

--- a/packages/client/src/components/ui/command.tsx
+++ b/packages/client/src/components/ui/command.tsx
@@ -6,21 +6,24 @@ import * as React from 'react';
 import { Dialog, DialogTitle, DialogPortal, DialogOverlay } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 
-const Command = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive>
->(({ className, ...props }, ref) => (
-  <CommandPrimitive
-    ref={ref}
-    className={cn(
-      'flex h-full w-full flex-col overflow-hidden rounded-lg bg-popover text-popover-foreground',
-      className,
-    )}
-    {...props}
-  />
-));
-Command.displayName = CommandPrimitive.displayName;
-
+function Command({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof CommandPrimitive> & {
+  ref?: React.Ref<React.ComponentRef<typeof CommandPrimitive>>;
+}) {
+  return (
+    <CommandPrimitive
+      ref={ref}
+      className={cn(
+        'flex h-full w-full flex-col overflow-hidden rounded-lg bg-popover text-popover-foreground',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 type CommandPrimitiveProps = React.ComponentPropsWithoutRef<typeof CommandPrimitive>;
 
 function CommandDialog({
@@ -66,36 +69,42 @@ function CommandDialog({
   );
 }
 
-const CommandInput = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive.Input>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
->(({ className, ...props }, ref) => (
-  <div className="flex items-center border-b border-border px-3" cmdk-input-wrapper="">
-    <Search className="icon-base mr-2 shrink-0 opacity-50" />
-    <CommandPrimitive.Input
+function CommandInput({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input> & {
+  ref?: React.Ref<React.ComponentRef<typeof CommandPrimitive.Input>>;
+}) {
+  return (
+    <div className="flex items-center border-b border-border px-3" cmdk-input-wrapper="">
+      <Search className="icon-base mr-2 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        ref={ref}
+        className={cn(
+          'flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+function CommandList({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof CommandPrimitive.List> & {
+  ref?: React.Ref<React.ComponentRef<typeof CommandPrimitive.List>>;
+}) {
+  return (
+    <CommandPrimitive.List
       ref={ref}
-      className={cn(
-        'flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
-        className,
-      )}
+      className={cn('max-h-[300px] overflow-y-auto overflow-x-hidden', className)}
       {...props}
     />
-  </div>
-));
-CommandInput.displayName = CommandPrimitive.Input.displayName;
-
-const CommandList = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
->(({ className, ...props }, ref) => (
-  <CommandPrimitive.List
-    ref={ref}
-    className={cn('max-h-[300px] overflow-y-auto overflow-x-hidden', className)}
-    {...props}
-  />
-));
-CommandList.displayName = CommandPrimitive.List.displayName;
-
+  );
+}
 const CommandEmpty = React.forwardRef<
   React.ComponentRef<typeof CommandPrimitive.Empty>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
@@ -108,48 +117,57 @@ const CommandEmpty = React.forwardRef<
 ));
 CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
 
-const CommandGroup = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive.Group>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
->(({ className, ...props }, ref) => (
-  <CommandPrimitive.Group
-    ref={ref}
-    className={cn(
-      'overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground',
-      className,
-    )}
-    {...props}
-  />
-));
-CommandGroup.displayName = CommandPrimitive.Group.displayName;
-
-const CommandSeparator = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <CommandPrimitive.Separator
-    ref={ref}
-    className={cn('-mx-1 h-px bg-border', className)}
-    {...props}
-  />
-));
-CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
-
-const CommandItem = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
->(({ className, ...props }, ref) => (
-  <CommandPrimitive.Item
-    ref={ref}
-    className={cn(
-      'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50',
-      className,
-    )}
-    {...props}
-  />
-));
-CommandItem.displayName = CommandPrimitive.Item.displayName;
-
+function CommandGroup({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group> & {
+  ref?: React.Ref<React.ComponentRef<typeof CommandPrimitive.Group>>;
+}) {
+  return (
+    <CommandPrimitive.Group
+      ref={ref}
+      className={cn(
+        'overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+function CommandSeparator({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator> & {
+  ref?: React.Ref<React.ComponentRef<typeof CommandPrimitive.Separator>>;
+}) {
+  return (
+    <CommandPrimitive.Separator
+      ref={ref}
+      className={cn('-mx-1 h-px bg-border', className)}
+      {...props}
+    />
+  );
+}
+function CommandItem({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item> & {
+  ref?: React.Ref<React.ComponentRef<typeof CommandPrimitive.Item>>;
+}) {
+  return (
+    <CommandPrimitive.Item
+      ref={ref}
+      className={cn(
+        'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 export {
   Command,
   CommandDialog,

--- a/packages/client/src/components/ui/context-menu.tsx
+++ b/packages/client/src/components/ui/context-menu.tsx
@@ -16,148 +16,177 @@ const ContextMenuSub = ContextMenuPrimitive.Sub;
 
 const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup;
 
-const ContextMenuSubTrigger = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.SubTrigger>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> & {
-    inset?: boolean;
-  }
->(({ className, inset, children, ...props }, ref) => (
-  <ContextMenuPrimitive.SubTrigger
-    ref={ref}
-    className={cn(
-      'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground',
-      inset && 'pl-8',
-      className,
-    )}
-    {...props}
-  >
-    {children}
-    <ChevronRight className="ml-auto size-4" />
-  </ContextMenuPrimitive.SubTrigger>
-));
-ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName;
-
-const ContextMenuSubContent = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
-  <ContextMenuPrimitive.SubContent
-    ref={ref}
-    className={cn(
-      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]',
-      className,
-    )}
-    {...props}
-  />
-));
-ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName;
-
-const ContextMenuContent = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <ContextMenuPrimitive.Portal>
-    <ContextMenuPrimitive.Content
+function ContextMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+} & { ref?: React.Ref<React.ElementRef<typeof ContextMenuPrimitive.SubTrigger>> }) {
+  return (
+    <ContextMenuPrimitive.SubTrigger
       ref={ref}
       className={cn(
-        'z-50 max-h-[--radix-context-menu-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]',
+        'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground',
+        inset && 'pl-8',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRight className="ml-auto size-4" />
+    </ContextMenuPrimitive.SubTrigger>
+  );
+}
+function ContextMenuSubContent({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent> & {
+  ref?: React.Ref<React.ElementRef<typeof ContextMenuPrimitive.SubContent>>;
+}) {
+  return (
+    <ContextMenuPrimitive.SubContent
+      ref={ref}
+      className={cn(
+        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]',
         className,
       )}
       {...props}
     />
-  </ContextMenuPrimitive.Portal>
-));
-ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName;
-
-const ContextMenuItem = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> & {
-    inset?: boolean;
-  }
->(({ className, inset, ...props }, ref) => (
-  <ContextMenuPrimitive.Item
-    ref={ref}
-    className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-      inset && 'pl-8',
-      className,
-    )}
-    {...props}
-  />
-));
-ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName;
-
-const ContextMenuCheckboxItem = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.CheckboxItem>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem>
->(({ className, children, checked, ...props }, ref) => (
-  <ContextMenuPrimitive.CheckboxItem
-    ref={ref}
-    className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-      className,
-    )}
-    checked={checked}
-    {...props}
-  >
-    <span className="absolute left-2 flex size-3.5 items-center justify-center">
-      <ContextMenuPrimitive.ItemIndicator>
-        <Check className="size-4" />
-      </ContextMenuPrimitive.ItemIndicator>
-    </span>
-    {children}
-  </ContextMenuPrimitive.CheckboxItem>
-));
-ContextMenuCheckboxItem.displayName = ContextMenuPrimitive.CheckboxItem.displayName;
-
-const ContextMenuRadioItem = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.RadioItem>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioItem>
->(({ className, children, ...props }, ref) => (
-  <ContextMenuPrimitive.RadioItem
-    ref={ref}
-    className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-      className,
-    )}
-    {...props}
-  >
-    <span className="absolute left-2 flex size-3.5 items-center justify-center">
-      <ContextMenuPrimitive.ItemIndicator>
-        <Circle className="size-2 fill-current" />
-      </ContextMenuPrimitive.ItemIndicator>
-    </span>
-    {children}
-  </ContextMenuPrimitive.RadioItem>
-));
-ContextMenuRadioItem.displayName = ContextMenuPrimitive.RadioItem.displayName;
-
-const ContextMenuLabel = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Label> & {
-    inset?: boolean;
-  }
->(({ className, inset, ...props }, ref) => (
-  <ContextMenuPrimitive.Label
-    ref={ref}
-    className={cn('px-2 py-1.5 text-sm font-semibold text-foreground', inset && 'pl-8', className)}
-    {...props}
-  />
-));
-ContextMenuLabel.displayName = ContextMenuPrimitive.Label.displayName;
-
-const ContextMenuSeparator = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <ContextMenuPrimitive.Separator
-    ref={ref}
-    className={cn('-mx-1 my-1 h-px bg-border', className)}
-    {...props}
-  />
-));
-ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName;
-
+  );
+}
+function ContextMenuContent({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content> & {
+  ref?: React.Ref<React.ElementRef<typeof ContextMenuPrimitive.Content>>;
+}) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Content
+        ref={ref}
+        className={cn(
+          'z-50 max-h-[--radix-context-menu-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]',
+          className,
+        )}
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
+  );
+}
+function ContextMenuItem({
+  className,
+  inset,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> & {
+  inset?: boolean;
+} & { ref?: React.Ref<React.ElementRef<typeof ContextMenuPrimitive.Item>> }) {
+  return (
+    <ContextMenuPrimitive.Item
+      ref={ref}
+      className={cn(
+        'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        inset && 'pl-8',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+function ContextMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem> & {
+  ref?: React.Ref<React.ElementRef<typeof ContextMenuPrimitive.CheckboxItem>>;
+}) {
+  return (
+    <ContextMenuPrimitive.CheckboxItem
+      ref={ref}
+      className={cn(
+        'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="absolute left-2 flex size-3.5 items-center justify-center">
+        <ContextMenuPrimitive.ItemIndicator>
+          <Check className="size-4" />
+        </ContextMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.CheckboxItem>
+  );
+}
+function ContextMenuRadioItem({
+  className,
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioItem> & {
+  ref?: React.Ref<React.ElementRef<typeof ContextMenuPrimitive.RadioItem>>;
+}) {
+  return (
+    <ContextMenuPrimitive.RadioItem
+      ref={ref}
+      className={cn(
+        'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute left-2 flex size-3.5 items-center justify-center">
+        <ContextMenuPrimitive.ItemIndicator>
+          <Circle className="size-2 fill-current" />
+        </ContextMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.RadioItem>
+  );
+}
+function ContextMenuLabel({
+  className,
+  inset,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Label> & {
+  inset?: boolean;
+} & { ref?: React.Ref<React.ElementRef<typeof ContextMenuPrimitive.Label>> }) {
+  return (
+    <ContextMenuPrimitive.Label
+      ref={ref}
+      className={cn(
+        'px-2 py-1.5 text-sm font-semibold text-foreground',
+        inset && 'pl-8',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+function ContextMenuSeparator({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator> & {
+  ref?: React.Ref<React.ElementRef<typeof ContextMenuPrimitive.Separator>>;
+}) {
+  return (
+    <ContextMenuPrimitive.Separator
+      ref={ref}
+      className={cn('-mx-1 my-1 h-px bg-border', className)}
+      {...props}
+    />
+  );
+}
 const ContextMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
   return (
     <span

--- a/packages/client/src/components/ui/copy-button.tsx
+++ b/packages/client/src/components/ui/copy-button.tsx
@@ -18,43 +18,37 @@ export interface CopyButtonProps extends Omit<ButtonProps, 'onClick' | 'children
   duration?: number;
 }
 
-const CopyButton = React.forwardRef<HTMLButtonElement, CopyButtonProps>(
-  (
-    {
-      value,
-      label = 'Copy',
-      copiedLabel = 'Copied!',
-      duration = 2000,
-      variant = 'ghost',
-      size = 'icon-xs',
-      className,
-      ...props
-    },
-    ref,
-  ) => {
-    const [copied, copy] = useCopyToClipboard(duration);
+function CopyButton({
+  value,
+  label = 'Copy',
+  copiedLabel = 'Copied!',
+  duration = 2000,
+  variant = 'ghost',
+  size = 'icon-xs',
+  className,
+  ref,
+  ...props
+}: CopyButtonProps & { ref?: React.Ref<HTMLButtonElement> }) {
+  const [copied, copy] = useCopyToClipboard(duration);
 
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            ref={ref}
-            data-testid="copy-button"
-            variant={variant}
-            size={size}
-            className={cn('text-muted-foreground hover:text-foreground', className)}
-            onClick={() => copy(value)}
-            aria-label={copied ? copiedLabel : label}
-            {...props}
-          >
-            {copied ? <Check /> : <Copy />}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>{copied ? copiedLabel : label}</TooltipContent>
-      </Tooltip>
-    );
-  },
-);
-CopyButton.displayName = 'CopyButton';
-
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          ref={ref}
+          data-testid="copy-button"
+          variant={variant}
+          size={size}
+          className={cn('text-muted-foreground hover:text-foreground', className)}
+          onClick={() => copy(value)}
+          aria-label={copied ? copiedLabel : label}
+          {...props}
+        >
+          {copied ? <Check /> : <Copy />}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{copied ? copiedLabel : label}</TooltipContent>
+    </Tooltip>
+  );
+}
 export { CopyButton };

--- a/packages/client/src/components/ui/dialog.stories.tsx
+++ b/packages/client/src/components/ui/dialog.stories.tsx
@@ -203,7 +203,7 @@ export const OpenAndClose: Story = {
           <DialogDescription>Testing open and close.</DialogDescription>
         </DialogHeader>
         <DialogFooter>
-          <Button data-testid="dialog-ok">OK</Button>
+          <Button data-testid="dialog-ok">Confirm action</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/packages/client/src/components/ui/dialog.tsx
+++ b/packages/client/src/components/ui/dialog.tsx
@@ -10,42 +10,49 @@ const DialogTrigger = DialogPrimitive.Trigger;
 const DialogPortal = DialogPrimitive.Portal;
 const DialogClose = DialogPrimitive.Close;
 
-const DialogOverlay = React.forwardRef<
-  React.ComponentRef<typeof DialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
-    ref={ref}
-    className={cn(
-      'fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-      className,
-    )}
-    {...props}
-  />
-));
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
-
-const DialogContent = React.forwardRef<
-  React.ComponentRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
+function DialogOverlay({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay> & {
+  ref?: React.Ref<React.ComponentRef<typeof DialogPrimitive.Overlay>>;
+}) {
+  return (
+    <DialogPrimitive.Overlay
       ref={ref}
-      aria-describedby={undefined}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-card p-6 shadow-xl duration-100 outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-lg',
+        'fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
         className,
       )}
       {...props}
-    >
-      {children}
-    </DialogPrimitive.Content>
-  </DialogPortal>
-));
-DialogContent.displayName = DialogPrimitive.Content.displayName;
-
+    />
+  );
+}
+function DialogContent({
+  className,
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+  ref?: React.Ref<React.ComponentRef<typeof DialogPrimitive.Content>>;
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        aria-describedby={undefined}
+        className={cn(
+          'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-card p-6 shadow-xl duration-100 outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-lg',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
 const DialogHeader = ({ className, children, ...props }: React.HTMLAttributes<HTMLDivElement>) => {
   // Separate DialogTitle and DialogDescription from other children
   const childArray = React.Children.toArray(children);
@@ -110,47 +117,60 @@ const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivEleme
 );
 DialogFooter.displayName = 'DialogFooter';
 
-const DialogTitle = React.forwardRef<
-  React.ComponentRef<typeof DialogPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title
-    ref={ref}
-    className={cn('text-base font-semibold leading-none tracking-tight', className)}
-    {...props}
-  />
-));
-DialogTitle.displayName = DialogPrimitive.Title.displayName;
-
-const DialogDescription = React.forwardRef<
-  React.ComponentRef<typeof DialogPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description
-    ref={ref}
-    className={cn('text-sm text-muted-foreground', className)}
-    {...props}
-  />
-));
-DialogDescription.displayName = DialogPrimitive.Description.displayName;
-
-const DialogCancelButton = React.forwardRef<
-  HTMLButtonElement,
-  React.ComponentPropsWithoutRef<'button'> & { children?: React.ReactNode }
->(({ children = 'Cancel', className, ...props }, ref) => (
-  <DialogPrimitive.Close asChild>
-    <button
+function DialogTitle({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title> & {
+  ref?: React.Ref<React.ComponentRef<typeof DialogPrimitive.Title>>;
+}) {
+  return (
+    <DialogPrimitive.Title
       ref={ref}
-      type="button"
-      className={cn(buttonVariants({ variant: 'outline' }), className)}
+      className={cn('text-base font-semibold leading-none tracking-tight', className)}
       {...props}
-    >
-      {children}
-    </button>
-  </DialogPrimitive.Close>
-));
-DialogCancelButton.displayName = 'DialogCancelButton';
+    />
+  );
+}
+DialogTitle.displayName = 'DialogTitle';
 
+function DialogDescription({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description> & {
+  ref?: React.Ref<React.ComponentRef<typeof DialogPrimitive.Description>>;
+}) {
+  return (
+    <DialogPrimitive.Description
+      ref={ref}
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+DialogDescription.displayName = 'DialogDescription';
+function DialogCancelButton({
+  children = 'Cancel',
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<'button'> & { children?: React.ReactNode } & {
+  ref?: React.Ref<HTMLButtonElement>;
+}) {
+  return (
+    <DialogPrimitive.Close asChild>
+      <button
+        ref={ref}
+        type="button"
+        className={cn(buttonVariants({ variant: 'outline' }), className)}
+        {...props}
+      >
+        {children}
+      </button>
+    </DialogPrimitive.Close>
+  );
+}
 export {
   Dialog,
   DialogPortal,

--- a/packages/client/src/components/ui/dropdown-menu.tsx
+++ b/packages/client/src/components/ui/dropdown-menu.tsx
@@ -27,22 +27,27 @@ const dropdownMenuContentVariants = cva(
   },
 );
 
-const DropdownMenuContent = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> &
-    VariantProps<typeof dropdownMenuContentVariants>
->(({ className, sideOffset = 4, size, ...props }, ref) => (
-  <DropdownMenuPrimitive.Portal>
-    <DropdownMenuPrimitive.Content
-      ref={ref}
-      sideOffset={sideOffset}
-      className={cn(dropdownMenuContentVariants({ size }), className)}
-      {...props}
-    />
-  </DropdownMenuPrimitive.Portal>
-));
-DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
-
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  size,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> &
+  VariantProps<typeof dropdownMenuContentVariants> & {
+    ref?: React.Ref<React.ComponentRef<typeof DropdownMenuPrimitive.Content>>;
+  }) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        ref={ref}
+        sideOffset={sideOffset}
+        className={cn(dropdownMenuContentVariants({ size }), className)}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
 const dropdownMenuItemVariants = cva(
   'relative flex cursor-pointer select-none items-center rounded-sm outline-none transition-colors focus-visible:bg-accent focus-visible:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
   {
@@ -59,37 +64,43 @@ const dropdownMenuItemVariants = cva(
   },
 );
 
-const DropdownMenuItem = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> &
-    VariantProps<typeof dropdownMenuItemVariants> & {
-      inset?: boolean;
-    }
->(({ className, inset, size, ...props }, ref) => (
-  <DropdownMenuPrimitive.Item
-    ref={ref}
-    className={cn(
-      dropdownMenuItemVariants({ size }),
-      inset && (size === 'xs' ? 'pl-6' : size === 'sm' ? 'pl-7' : 'pl-8'),
-      className,
-    )}
-    {...props}
-  />
-));
-DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
-
-const DropdownMenuSeparator = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.Separator
-    ref={ref}
-    className={cn('-mx-1 my-1 h-px bg-muted', className)}
-    {...props}
-  />
-));
-DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
-
+function DropdownMenuItem({
+  className,
+  inset,
+  size,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> &
+  VariantProps<typeof dropdownMenuItemVariants> & {
+    inset?: boolean;
+  } & { ref?: React.Ref<React.ComponentRef<typeof DropdownMenuPrimitive.Item>> }) {
+  return (
+    <DropdownMenuPrimitive.Item
+      ref={ref}
+      className={cn(
+        dropdownMenuItemVariants({ size }),
+        inset && (size === 'xs' ? 'pl-6' : size === 'sm' ? 'pl-7' : 'pl-8'),
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+function DropdownMenuSeparator({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator> & {
+  ref?: React.Ref<React.ComponentRef<typeof DropdownMenuPrimitive.Separator>>;
+}) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      ref={ref}
+      className={cn('-mx-1 my-1 h-px bg-muted', className)}
+      {...props}
+    />
+  );
+}
 const dropdownMenuSubTriggerVariants = cva(
   'flex cursor-pointer select-none items-center rounded-sm outline-none focus-visible:bg-accent data-[state=open]:bg-accent',
   {
@@ -106,45 +117,53 @@ const dropdownMenuSubTriggerVariants = cva(
   },
 );
 
-const DropdownMenuSubTrigger = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.SubTrigger>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> &
-    VariantProps<typeof dropdownMenuSubTriggerVariants> & {
-      inset?: boolean;
-    }
->(({ className, inset, size, children, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubTrigger
-    ref={ref}
-    className={cn(
-      dropdownMenuSubTriggerVariants({ size }),
-      inset && (size === 'xs' ? 'pl-6' : size === 'sm' ? 'pl-7' : 'pl-8'),
-      className,
-    )}
-    {...props}
-  >
-    {children}
-    <ChevronRight className="ml-auto" />
-  </DropdownMenuPrimitive.SubTrigger>
-));
-DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
-
-const DropdownMenuSubContent = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.SubContent>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent> &
-    VariantProps<typeof dropdownMenuContentVariants>
->(({ className, size, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubContent
-    ref={ref}
-    className={cn(
-      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-      size === 'xs' ? 'p-0.5' : size === 'sm' ? 'p-1' : 'p-1',
-      className,
-    )}
-    {...props}
-  />
-));
-DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
-
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  size,
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> &
+  VariantProps<typeof dropdownMenuSubTriggerVariants> & {
+    inset?: boolean;
+  } & { ref?: React.Ref<React.ComponentRef<typeof DropdownMenuPrimitive.SubTrigger>> }) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      ref={ref}
+      className={cn(
+        dropdownMenuSubTriggerVariants({ size }),
+        inset && (size === 'xs' ? 'pl-6' : size === 'sm' ? 'pl-7' : 'pl-8'),
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRight className="ml-auto" />
+    </DropdownMenuPrimitive.SubTrigger>
+  );
+}
+function DropdownMenuSubContent({
+  className,
+  size,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent> &
+  VariantProps<typeof dropdownMenuContentVariants> & {
+    ref?: React.Ref<React.ComponentRef<typeof DropdownMenuPrimitive.SubContent>>;
+  }) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      ref={ref}
+      className={cn(
+        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        size === 'xs' ? 'p-0.5' : size === 'sm' ? 'p-1' : 'p-1',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 export {
   DropdownMenu,
   DropdownMenuTrigger,

--- a/packages/client/src/components/ui/hover-card.tsx
+++ b/packages/client/src/components/ui/hover-card.tsx
@@ -7,21 +7,26 @@ const HoverCard = HoverCardPrimitive.Root;
 
 const HoverCardTrigger = HoverCardPrimitive.Trigger;
 
-const HoverCardContent = React.forwardRef<
-  React.ElementRef<typeof HoverCardPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
->(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
-  <HoverCardPrimitive.Content
-    ref={ref}
-    align={align}
-    sideOffset={sideOffset}
-    className={cn(
-      'z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-hover-card-content-transform-origin]',
-      className,
-    )}
-    {...props}
-  />
-));
-HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
-
+function HoverCardContent({
+  className,
+  align = 'center',
+  sideOffset = 4,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content> & {
+  ref?: React.Ref<React.ElementRef<typeof HoverCardPrimitive.Content>>;
+}) {
+  return (
+    <HoverCardPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-hover-card-content-transform-origin]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 export { HoverCard, HoverCardTrigger, HoverCardContent };

--- a/packages/client/src/components/ui/input.tsx
+++ b/packages/client/src/components/ui/input.tsx
@@ -2,21 +2,22 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
-const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
-  ({ className, type, ...props }, ref) => {
-    return (
-      <input
-        type={type}
-        className={cn(
-          'flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50',
-          className,
-        )}
-        ref={ref}
-        {...props}
-      />
-    );
-  },
-);
-Input.displayName = 'Input';
-
+function Input({
+  className,
+  type,
+  ref,
+  ...props
+}: React.ComponentProps<'input'> & { ref?: React.Ref<HTMLInputElement> }) {
+  return (
+    <input
+      type={type}
+      className={cn(
+        'flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+}
 export { Input };

--- a/packages/client/src/components/ui/popover.tsx
+++ b/packages/client/src/components/ui/popover.tsx
@@ -1,28 +1,34 @@
 import * as PopoverPrimitive from '@radix-ui/react-popover';
-import * as React from 'react';
+import type * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
 const Popover = PopoverPrimitive.Root;
 const PopoverTrigger = PopoverPrimitive.Trigger;
 
-const PopoverContent = React.forwardRef<
-  React.ComponentRef<typeof PopoverPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
-    <PopoverPrimitive.Content
-      ref={ref}
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        'z-50 w-72 rounded-md border bg-card p-4 shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        className,
-      )}
-      {...props}
-    />
-  </PopoverPrimitive.Portal>
-));
-PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+function PopoverContent({
+  className,
+  align = 'center',
+  sideOffset = 4,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
+  ref?: React.Ref<React.ComponentRef<typeof PopoverPrimitive.Content>>;
+}) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        ref={ref}
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 w-72 rounded-md border bg-card p-4 shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
 
 export { Popover, PopoverTrigger, PopoverContent };

--- a/packages/client/src/components/ui/scroll-area.tsx
+++ b/packages/client/src/components/ui/scroll-area.tsx
@@ -11,10 +11,14 @@ interface ScrollAreaProps extends React.ComponentPropsWithoutRef<typeof ScrollAr
   >;
 }
 
-const ScrollArea = React.forwardRef<
-  React.ComponentRef<typeof ScrollAreaPrimitive.Root>,
-  ScrollAreaProps
->(({ className, children, viewportRef, viewportProps, ...props }, ref) => {
+function ScrollArea({
+  className,
+  children,
+  viewportRef,
+  viewportProps,
+  ref,
+  ...props
+}: ScrollAreaProps & { ref?: React.Ref<React.ComponentRef<typeof ScrollAreaPrimitive.Root>> }) {
   const { className: viewportClassName, ...restViewportProps } = viewportProps ?? {};
   return (
     <ScrollAreaPrimitive.Root
@@ -37,27 +41,29 @@ const ScrollArea = React.forwardRef<
       <ScrollAreaPrimitive.Corner />
     </ScrollAreaPrimitive.Root>
   );
-});
-ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
-
-const ScrollBar = React.forwardRef<
-  React.ComponentRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
->(({ className, orientation = 'vertical', ...props }, ref) => (
-  <ScrollAreaPrimitive.ScrollAreaScrollbar
-    ref={ref}
-    orientation={orientation}
-    className={cn(
-      'flex touch-none select-none transition-colors',
-      orientation === 'vertical' && 'h-full w-2 border-l border-l-transparent p-[1px]',
-      orientation === 'horizontal' && 'h-2 flex-col border-t border-t-transparent p-[1px]',
-      className,
-    )}
-    {...props}
-  >
-    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
-  </ScrollAreaPrimitive.ScrollAreaScrollbar>
-));
-ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
-
+}
+function ScrollBar({
+  className,
+  orientation = 'vertical',
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar> & {
+  ref?: React.Ref<React.ComponentRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>>;
+}) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      ref={ref}
+      orientation={orientation}
+      className={cn(
+        'flex touch-none select-none transition-colors',
+        orientation === 'vertical' && 'h-full w-2 border-l border-l-transparent p-[1px]',
+        orientation === 'horizontal' && 'h-2 flex-col border-t border-t-transparent p-[1px]',
+        className,
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  );
+}
 export { ScrollArea, ScrollBar };

--- a/packages/client/src/components/ui/select.tsx
+++ b/packages/client/src/components/ui/select.tsx
@@ -25,98 +25,118 @@ const selectTriggerVariants = cva(
   },
 );
 
-const SelectTrigger = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> &
-    VariantProps<typeof selectTriggerVariants> & { hideChevron?: boolean }
->(({ className, children, size, hideChevron, ...props }, ref) => (
-  <SelectPrimitive.Trigger
-    ref={ref}
-    className={cn(selectTriggerVariants({ size }), className)}
-    {...props}
-  >
-    {children}
-    {!hideChevron && (
-      <SelectPrimitive.Icon asChild>
-        <ChevronDown className={cn(size === 'default' ? 'icon-base' : 'icon-xs', 'opacity-50')} />
-      </SelectPrimitive.Icon>
-    )}
-  </SelectPrimitive.Trigger>
-));
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
-
-const SelectScrollUpButton = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.ScrollUpButton>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.ScrollUpButton
-    ref={ref}
-    className={cn('flex cursor-default items-center justify-center py-1', className)}
-    {...props}
-  >
-    <ChevronUp className="icon-xs" />
-  </SelectPrimitive.ScrollUpButton>
-));
-SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
-
-const SelectScrollDownButton = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.ScrollDownButton>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.ScrollDownButton
-    ref={ref}
-    className={cn('flex cursor-default items-center justify-center py-1', className)}
-    {...props}
-  >
-    <ChevronDown className="icon-xs" />
-  </SelectPrimitive.ScrollDownButton>
-));
-SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
-
-const SelectContent = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = 'popper', ...props }, ref) => (
-  <SelectPrimitive.Portal>
-    <SelectPrimitive.Content
+function SelectTrigger({
+  className,
+  children,
+  size,
+  hideChevron,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> &
+  VariantProps<typeof selectTriggerVariants> & { hideChevron?: boolean } & {
+    ref?: React.Ref<React.ComponentRef<typeof SelectPrimitive.Trigger>>;
+  }) {
+  return (
+    <SelectPrimitive.Trigger
       ref={ref}
-      className={cn(
-        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        position === 'popper' &&
-          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
-        className,
-      )}
-      position={position}
+      className={cn(selectTriggerVariants({ size }), className)}
       {...props}
     >
-      <SelectScrollUpButton />
-      <SelectPrimitive.Viewport
+      {children}
+      {!hideChevron && (
+        <SelectPrimitive.Icon asChild>
+          <ChevronDown className={cn(size === 'default' ? 'icon-base' : 'icon-xs', 'opacity-50')} />
+        </SelectPrimitive.Icon>
+      )}
+    </SelectPrimitive.Trigger>
+  );
+}
+function SelectScrollUpButton({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton> & {
+  ref?: React.Ref<React.ComponentRef<typeof SelectPrimitive.ScrollUpButton>>;
+}) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      ref={ref}
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
+      {...props}
+    >
+      <ChevronUp className="icon-xs" />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+function SelectScrollDownButton({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton> & {
+  ref?: React.Ref<React.ComponentRef<typeof SelectPrimitive.ScrollDownButton>>;
+}) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      ref={ref}
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
+      {...props}
+    >
+      <ChevronDown className="icon-xs" />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+function SelectContent({
+  className,
+  children,
+  position = 'popper',
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content> & {
+  ref?: React.Ref<React.ComponentRef<typeof SelectPrimitive.Content>>;
+}) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        ref={ref}
         className={cn(
-          'p-1',
+          'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
           position === 'popper' &&
-            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]',
+            'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          className,
         )}
+        position={position}
+        {...props}
       >
-        {children}
-      </SelectPrimitive.Viewport>
-      <SelectScrollDownButton />
-    </SelectPrimitive.Content>
-  </SelectPrimitive.Portal>
-));
-SelectContent.displayName = SelectPrimitive.Content.displayName;
-
-const SelectLabel = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.Label
-    ref={ref}
-    className={cn('px-2 py-1.5 text-xs font-semibold', className)}
-    {...props}
-  />
-));
-SelectLabel.displayName = SelectPrimitive.Label.displayName;
-
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            'p-1',
+            position === 'popper' &&
+              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]',
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+function SelectLabel({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label> & {
+  ref?: React.Ref<React.ComponentRef<typeof SelectPrimitive.Label>>;
+}) {
+  return (
+    <SelectPrimitive.Label
+      ref={ref}
+      className={cn('px-2 py-1.5 text-xs font-semibold', className)}
+      {...props}
+    />
+  );
+}
 const selectItemVariants = cva(
   'relative flex w-full cursor-pointer select-none items-center rounded-sm outline-none hover:bg-accent/50 focus-visible:bg-accent focus-visible:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
   {
@@ -133,43 +153,51 @@ const selectItemVariants = cva(
   },
 );
 
-const SelectItem = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item> &
-    VariantProps<typeof selectItemVariants>
->(({ className, children, size, ...props }, ref) => (
-  <SelectPrimitive.Item
-    ref={ref}
-    className={cn(selectItemVariants({ size }), className)}
-    {...props}
-  >
-    <span
-      className={cn(
-        'absolute flex items-center justify-center',
-        size === 'xs' ? 'right-1.5 h-3 w-3' : 'right-2 h-3.5 w-3.5',
-      )}
+function SelectItem({
+  className,
+  children,
+  size,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item> &
+  VariantProps<typeof selectItemVariants> & {
+    ref?: React.Ref<React.ComponentRef<typeof SelectPrimitive.Item>>;
+  }) {
+  return (
+    <SelectPrimitive.Item
+      ref={ref}
+      className={cn(selectItemVariants({ size }), className)}
+      {...props}
     >
-      <SelectPrimitive.ItemIndicator>
-        <Check className={cn(size === 'xs' ? 'icon-2xs' : 'icon-xs')} />
-      </SelectPrimitive.ItemIndicator>
-    </span>
-    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-  </SelectPrimitive.Item>
-));
-SelectItem.displayName = SelectPrimitive.Item.displayName;
-
-const SelectSeparator = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.Separator
-    ref={ref}
-    className={cn('-mx-1 my-1 h-px bg-muted', className)}
-    {...props}
-  />
-));
-SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
-
+      <span
+        className={cn(
+          'absolute flex items-center justify-center',
+          size === 'xs' ? 'right-1.5 h-3 w-3' : 'right-2 h-3.5 w-3.5',
+        )}
+      >
+        <SelectPrimitive.ItemIndicator>
+          <Check className={cn(size === 'xs' ? 'icon-2xs' : 'icon-xs')} />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+function SelectSeparator({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator> & {
+  ref?: React.Ref<React.ComponentRef<typeof SelectPrimitive.Separator>>;
+}) {
+  return (
+    <SelectPrimitive.Separator
+      ref={ref}
+      className={cn('-mx-1 my-1 h-px bg-muted', className)}
+      {...props}
+    />
+  );
+}
 export {
   Select,
   SelectGroup,

--- a/packages/client/src/components/ui/separator.tsx
+++ b/packages/client/src/components/ui/separator.tsx
@@ -3,22 +3,27 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
-const Separator = React.forwardRef<
-  React.ElementRef<typeof SeparatorPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
->(({ className, orientation = 'horizontal', decorative = true, ...props }, ref) => (
-  <SeparatorPrimitive.Root
-    ref={ref}
-    decorative={decorative}
-    orientation={orientation}
-    className={cn(
-      'shrink-0 bg-border',
-      orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
-      className,
-    )}
-    {...props}
-  />
-));
-Separator.displayName = SeparatorPrimitive.Root.displayName;
-
+function Separator({
+  className,
+  orientation = 'horizontal',
+  decorative = true,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root> & {
+  ref?: React.Ref<React.ElementRef<typeof SeparatorPrimitive.Root>>;
+}) {
+  return (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        'shrink-0 bg-border',
+        orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 export { Separator };

--- a/packages/client/src/components/ui/sheet.tsx
+++ b/packages/client/src/components/ui/sheet.tsx
@@ -15,21 +15,24 @@ const SheetClose = SheetPrimitive.Close;
 
 const SheetPortal = SheetPrimitive.Portal;
 
-const SheetOverlay = React.forwardRef<
-  React.ElementRef<typeof SheetPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-  <SheetPrimitive.Overlay
-    className={cn(
-      'fixed inset-0 z-50 bg-black/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-      className,
-    )}
-    {...props}
-    ref={ref}
-  />
-));
-SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
-
+function SheetOverlay({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay> & {
+  ref?: React.Ref<React.ElementRef<typeof SheetPrimitive.Overlay>>;
+}) {
+  return (
+    <SheetPrimitive.Overlay
+      className={cn(
+        'fixed inset-0 z-50 bg-black/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        className,
+      )}
+      {...props}
+      ref={ref}
+    />
+  );
+}
 const sheetVariants = cva(
   'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
   {
@@ -54,23 +57,30 @@ interface SheetContentProps
     React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {}
 
-const SheetContent = React.forwardRef<
-  React.ElementRef<typeof SheetPrimitive.Content>,
-  SheetContentProps
->(({ side = 'right', className, children, ...props }, ref) => (
-  <SheetPortal>
-    <SheetOverlay />
-    <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
-      {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="icon-base" />
-        <span className="sr-only">Close</span>
-      </SheetPrimitive.Close>
-    </SheetPrimitive.Content>
-  </SheetPortal>
-));
-SheetContent.displayName = SheetPrimitive.Content.displayName;
-
+function SheetContent({
+  side = 'right',
+  className,
+  children,
+  ref,
+  ...props
+}: SheetContentProps & { ref?: React.Ref<React.ElementRef<typeof SheetPrimitive.Content>> }) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        ref={ref}
+        className={cn(sheetVariants({ side }), className)}
+        {...props}
+      >
+        {children}
+        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50 disabled:pointer-events-none data-[state=open]:bg-secondary">
+          <X className="icon-base" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  );
+}
 const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
 );
@@ -84,30 +94,36 @@ const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElemen
 );
 SheetFooter.displayName = 'SheetFooter';
 
-const SheetTitle = React.forwardRef<
-  React.ElementRef<typeof SheetPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
->(({ className, ...props }, ref) => (
-  <SheetPrimitive.Title
-    ref={ref}
-    className={cn('text-lg font-semibold text-foreground', className)}
-    {...props}
-  />
-));
-SheetTitle.displayName = SheetPrimitive.Title.displayName;
-
-const SheetDescription = React.forwardRef<
-  React.ElementRef<typeof SheetPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
->(({ className, ...props }, ref) => (
-  <SheetPrimitive.Description
-    ref={ref}
-    className={cn('text-sm text-muted-foreground', className)}
-    {...props}
-  />
-));
-SheetDescription.displayName = SheetPrimitive.Description.displayName;
-
+function SheetTitle({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title> & {
+  ref?: React.Ref<React.ElementRef<typeof SheetPrimitive.Title>>;
+}) {
+  return (
+    <SheetPrimitive.Title
+      ref={ref}
+      className={cn('text-lg font-semibold text-foreground', className)}
+      {...props}
+    />
+  );
+}
+function SheetDescription({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description> & {
+  ref?: React.Ref<React.ElementRef<typeof SheetPrimitive.Description>>;
+}) {
+  return (
+    <SheetPrimitive.Description
+      ref={ref}
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
 export {
   Sheet,
   SheetPortal,

--- a/packages/client/src/components/ui/sidebar.tsx
+++ b/packages/client/src/components/ui/sidebar.tsx
@@ -54,181 +54,134 @@ function useSidebar() {
   return context;
 }
 
-const SidebarProvider = React.forwardRef<
-  HTMLDivElement,
-  React.ComponentProps<'div'> & {
-    defaultOpen?: boolean;
-    open?: boolean;
-    onOpenChange?: (open: boolean) => void;
-    keyboardShortcut?: boolean;
-  }
->(
-  (
-    {
-      defaultOpen = true,
-      open: openProp,
-      onOpenChange: setOpenProp,
-      keyboardShortcut: enableKeyboardShortcut = true,
-      className,
-      style,
-      children,
-      ...props
+function SidebarProvider({
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange: setOpenProp,
+  keyboardShortcut: enableKeyboardShortcut = true,
+  className,
+  style,
+  children,
+  ref,
+  ...props
+}: React.ComponentProps<'div'> & {
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  keyboardShortcut?: boolean;
+} & { ref?: React.Ref<HTMLDivElement> }) {
+  const isMobile = useIsMobile();
+  const [openMobile, setOpenMobile] = React.useState(false);
+
+  // Resizable sidebar width (persisted in localStorage)
+  const [sidebarWidth, _setSidebarWidth] = React.useState(() => {
+    const stored = localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
+    return stored ? Number(stored) : 320;
+  });
+  const [isResizing, setIsResizing] = React.useState(false);
+  const setSidebarWidth = React.useCallback((width: number) => {
+    const clamped = Math.max(SIDEBAR_MIN_WIDTH, Math.min(SIDEBAR_MAX_WIDTH, width));
+    _setSidebarWidth(clamped);
+    localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(clamped));
+  }, []);
+
+  // This is the internal state of the sidebar.
+  // We use openProp and setOpenProp for control from outside the component.
+  const [_open, _setOpen] = React.useState(() => {
+    if (typeof document === 'undefined') return defaultOpen;
+    const match = document.cookie
+      .split('; ')
+      .find((row) => row.startsWith(`${SIDEBAR_COOKIE_NAME}=`));
+    if (!match) return defaultOpen;
+    return match.split('=')[1] === 'true';
+  });
+  const open = openProp ?? _open;
+  const setOpen = React.useCallback(
+    (value: boolean | ((value: boolean) => boolean)) => {
+      const openState = typeof value === 'function' ? value(open) : value;
+      if (setOpenProp) {
+        setOpenProp(openState);
+      } else {
+        _setOpen(openState);
+      }
+
+      // This sets the cookie to keep the sidebar state.
+      // Security M2: use SameSite=Lax to block cross-site reads and set
+      // Secure on https:// origins so the cookie can't leak over plain
+      // http. We can't HttpOnly here — the client needs to read it.
+      const isSecureOrigin = typeof window !== 'undefined' && window.location.protocol === 'https:';
+      const secureAttr = isSecureOrigin ? '; Secure' : '';
+      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}; SameSite=Lax${secureAttr}`;
     },
-    ref,
-  ) => {
-    const isMobile = useIsMobile();
-    const [openMobile, setOpenMobile] = React.useState(false);
+    [setOpenProp, open],
+  );
 
-    // Resizable sidebar width (persisted in localStorage)
-    const [sidebarWidth, _setSidebarWidth] = React.useState(() => {
-      const stored = localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
-      return stored ? Number(stored) : 320;
-    });
-    const [isResizing, setIsResizing] = React.useState(false);
-    const setSidebarWidth = React.useCallback((width: number) => {
-      const clamped = Math.max(SIDEBAR_MIN_WIDTH, Math.min(SIDEBAR_MAX_WIDTH, width));
-      _setSidebarWidth(clamped);
-      localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(clamped));
-    }, []);
+  // Helper to toggle the sidebar.
+  const toggleSidebar = React.useCallback(() => {
+    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
+  }, [isMobile, setOpen, setOpenMobile]);
 
-    // This is the internal state of the sidebar.
-    // We use openProp and setOpenProp for control from outside the component.
-    const [_open, _setOpen] = React.useState(() => {
-      if (typeof document === 'undefined') return defaultOpen;
-      const match = document.cookie
-        .split('; ')
-        .find((row) => row.startsWith(`${SIDEBAR_COOKIE_NAME}=`));
-      if (!match) return defaultOpen;
-      return match.split('=')[1] === 'true';
-    });
-    const open = openProp ?? _open;
-    const setOpen = React.useCallback(
-      (value: boolean | ((value: boolean) => boolean)) => {
-        const openState = typeof value === 'function' ? value(open) : value;
-        if (setOpenProp) {
-          setOpenProp(openState);
-        } else {
-          _setOpen(openState);
-        }
+  // Adds a keyboard shortcut to toggle the sidebar.
+  React.useEffect(() => {
+    if (!enableKeyboardShortcut) return;
 
-        // This sets the cookie to keep the sidebar state.
-        // Security M2: use SameSite=Lax to block cross-site reads and set
-        // Secure on https:// origins so the cookie can't leak over plain
-        // http. We can't HttpOnly here — the client needs to read it.
-        const isSecureOrigin =
-          typeof window !== 'undefined' && window.location.protocol === 'https:';
-        const secureAttr = isSecureOrigin ? '; Secure' : '';
-        document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}; SameSite=Lax${secureAttr}`;
-      },
-      [setOpenProp, open],
-    );
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === SIDEBAR_KEYBOARD_SHORTCUT && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        toggleSidebar();
+      }
+    };
 
-    // Helper to toggle the sidebar.
-    const toggleSidebar = React.useCallback(() => {
-      return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
-    }, [isMobile, setOpen, setOpenMobile]);
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [toggleSidebar, enableKeyboardShortcut]);
 
-    // Adds a keyboard shortcut to toggle the sidebar.
-    React.useEffect(() => {
-      if (!enableKeyboardShortcut) return;
+  // We add a state so that we can do data-state="expanded" or "collapsed".
+  // This makes it easier to style the sidebar with Tailwind classes.
+  const state = open ? 'expanded' : 'collapsed';
 
-      const handleKeyDown = (event: KeyboardEvent) => {
-        if (event.key === SIDEBAR_KEYBOARD_SHORTCUT && (event.metaKey || event.ctrlKey)) {
-          event.preventDefault();
-          toggleSidebar();
-        }
-      };
+  const contextValue = React.useMemo<SidebarContextProps>(
+    () => ({
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+      sidebarWidth,
+      setSidebarWidth,
+      isResizing,
+      setIsResizing,
+    }),
+    [
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+      sidebarWidth,
+      setSidebarWidth,
+      isResizing,
+      setIsResizing,
+    ],
+  );
 
-      window.addEventListener('keydown', handleKeyDown);
-      return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [toggleSidebar, enableKeyboardShortcut]);
-
-    // We add a state so that we can do data-state="expanded" or "collapsed".
-    // This makes it easier to style the sidebar with Tailwind classes.
-    const state = open ? 'expanded' : 'collapsed';
-
-    const contextValue = React.useMemo<SidebarContextProps>(
-      () => ({
-        state,
-        open,
-        setOpen,
-        isMobile,
-        openMobile,
-        setOpenMobile,
-        toggleSidebar,
-        sidebarWidth,
-        setSidebarWidth,
-        isResizing,
-        setIsResizing,
-      }),
-      [
-        state,
-        open,
-        setOpen,
-        isMobile,
-        openMobile,
-        setOpenMobile,
-        toggleSidebar,
-        sidebarWidth,
-        setSidebarWidth,
-        isResizing,
-        setIsResizing,
-      ],
-    );
-
-    return (
-      <SidebarContext.Provider value={contextValue}>
-        <TooltipProvider delayDuration={0} disableHoverableContent>
-          <div
-            style={
-              {
-                '--sidebar-width': `${sidebarWidth}px`,
-                '--sidebar-width-icon': SIDEBAR_WIDTH_ICON,
-                ...style,
-              } as React.CSSProperties
-            }
-            className={cn(
-              'group/sidebar-wrapper flex min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar',
-              className,
-            )}
-            ref={ref}
-            {...props}
-          >
-            {children}
-          </div>
-        </TooltipProvider>
-      </SidebarContext.Provider>
-    );
-  },
-);
-SidebarProvider.displayName = 'SidebarProvider';
-
-const Sidebar = React.forwardRef<
-  HTMLDivElement,
-  React.ComponentProps<'div'> & {
-    side?: 'left' | 'right';
-    variant?: 'sidebar' | 'floating' | 'inset';
-    collapsible?: 'offcanvas' | 'icon' | 'none';
-  }
->(
-  (
-    {
-      side = 'left',
-      variant = 'sidebar',
-      collapsible = 'offcanvas',
-      className,
-      children,
-      ...props
-    },
-    ref,
-  ) => {
-    const { isMobile, state, openMobile, setOpenMobile, isResizing } = useSidebar();
-
-    if (collapsible === 'none') {
-      return (
+  return (
+    <SidebarContext.Provider value={contextValue}>
+      <TooltipProvider delayDuration={0} disableHoverableContent>
         <div
+          style={
+            {
+              '--sidebar-width': `${sidebarWidth}px`,
+              '--sidebar-width-icon': SIDEBAR_WIDTH_ICON,
+              ...style,
+            } as React.CSSProperties
+          }
           className={cn(
-            'flex h-full w-[--sidebar-width] flex-col bg-sidebar text-sidebar-foreground',
+            'group/sidebar-wrapper flex min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar',
             className,
           )}
           ref={ref}
@@ -236,86 +189,116 @@ const Sidebar = React.forwardRef<
         >
           {children}
         </div>
-      );
-    }
+      </TooltipProvider>
+    </SidebarContext.Provider>
+  );
+}
+function Sidebar({
+  side = 'left',
+  variant = 'sidebar',
+  collapsible = 'offcanvas',
+  className,
+  children,
+  ref,
+  ...props
+}: React.ComponentProps<'div'> & {
+  side?: 'left' | 'right';
+  variant?: 'sidebar' | 'floating' | 'inset';
+  collapsible?: 'offcanvas' | 'icon' | 'none';
+} & { ref?: React.Ref<HTMLDivElement> }) {
+  const { isMobile, state, openMobile, setOpenMobile, isResizing } = useSidebar();
 
-    if (isMobile) {
-      return (
-        <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
-          <SheetContent
-            data-sidebar="sidebar"
-            data-mobile="true"
-            className="w-[--sidebar-width] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
-            style={
-              {
-                '--sidebar-width': SIDEBAR_WIDTH_MOBILE,
-              } as React.CSSProperties
-            }
-            side={side}
-          >
-            <SheetHeader className="sr-only">
-              <SheetTitle>Sidebar</SheetTitle>
-              <SheetDescription>Displays the mobile sidebar.</SheetDescription>
-            </SheetHeader>
-            <div className="flex h-full w-full flex-col">{children}</div>
-          </SheetContent>
-        </Sheet>
-      );
-    }
-
+  if (collapsible === 'none') {
     return (
       <div
+        className={cn(
+          'flex h-full w-[--sidebar-width] flex-col bg-sidebar text-sidebar-foreground',
+          className,
+        )}
         ref={ref}
-        className="group peer hidden text-sidebar-foreground md:block"
-        data-state={state}
-        data-collapsible={state === 'collapsed' ? collapsible : ''}
-        data-variant={variant}
-        data-side={side}
+        {...props}
       >
-        {/* This is what handles the sidebar gap on desktop */}
-        <div
-          className={cn(
-            'relative w-[--sidebar-width] bg-transparent',
-            !isResizing && 'transition-[width] duration-200 ease-linear',
-            'group-data-[collapsible=offcanvas]:w-0',
-            'group-data-[side=right]:rotate-180',
-            variant === 'floating' || variant === 'inset'
-              ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]'
-              : 'group-data-[collapsible=icon]:w-[--sidebar-width-icon]',
-          )}
-        />
-        <div
-          className={cn(
-            'fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] md:flex',
-            !isResizing && 'transition-[left,right,width] duration-200 ease-linear',
-            side === 'left'
-              ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
-              : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
-            // Adjust the padding for floating and inset variants.
-            variant === 'floating' || variant === 'inset'
-              ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]'
-              : 'group-data-[collapsible=icon]:w-[--sidebar-width-icon]',
-            className,
-          )}
-          {...props}
-        >
-          <div
-            data-sidebar="sidebar"
-            className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
-          >
-            {children}
-          </div>
-        </div>
+        {children}
       </div>
     );
-  },
-);
-Sidebar.displayName = 'Sidebar';
+  }
 
-const SidebarTrigger = React.forwardRef<
-  React.ElementRef<typeof Button>,
-  React.ComponentProps<typeof Button>
->(({ className, onClick, ...props }, ref) => {
+  if (isMobile) {
+    return (
+      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+        <SheetContent
+          data-sidebar="sidebar"
+          data-mobile="true"
+          className="w-[--sidebar-width] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+          style={
+            {
+              '--sidebar-width': SIDEBAR_WIDTH_MOBILE,
+            } as React.CSSProperties
+          }
+          side={side}
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <div
+      ref={ref}
+      className="group peer hidden text-sidebar-foreground md:block"
+      data-state={state}
+      data-collapsible={state === 'collapsed' ? collapsible : ''}
+      data-variant={variant}
+      data-side={side}
+    >
+      {/* This is what handles the sidebar gap on desktop */}
+      <div
+        className={cn(
+          'relative w-[--sidebar-width] bg-transparent',
+          !isResizing && 'transition-[width] duration-200 ease-linear',
+          'group-data-[collapsible=offcanvas]:w-0',
+          'group-data-[side=right]:rotate-180',
+          variant === 'floating' || variant === 'inset'
+            ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]'
+            : 'group-data-[collapsible=icon]:w-[--sidebar-width-icon]',
+        )}
+      />
+      <div
+        className={cn(
+          'fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] md:flex',
+          !isResizing && 'transition-[left,right,width] duration-200 ease-linear',
+          side === 'left'
+            ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
+            : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
+          // Adjust the padding for floating and inset variants.
+          variant === 'floating' || variant === 'inset'
+            ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]'
+            : 'group-data-[collapsible=icon]:w-[--sidebar-width-icon]',
+          className,
+        )}
+        {...props}
+      >
+        <div
+          data-sidebar="sidebar"
+          className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+function SidebarTrigger({
+  className,
+  onClick,
+  ref,
+  ...props
+}: React.ComponentProps<typeof Button> & { ref?: React.Ref<React.ElementRef<typeof Button>> }) {
   const { toggleSidebar } = useSidebar();
 
   return (
@@ -335,9 +318,7 @@ const SidebarTrigger = React.forwardRef<
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   );
-});
-SidebarTrigger.displayName = 'SidebarTrigger';
-
+}
 const SidebarRail = React.forwardRef<HTMLButtonElement, React.ComponentProps<'button'>>(
   ({ className, ...props }, ref) => {
     const { toggleSidebar, sidebarWidth, setSidebarWidth, setIsResizing } = useSidebar();
@@ -424,27 +405,28 @@ const SidebarRail = React.forwardRef<HTMLButtonElement, React.ComponentProps<'bu
 );
 SidebarRail.displayName = 'SidebarRail';
 
-const SidebarInset = React.forwardRef<HTMLDivElement, React.ComponentProps<'main'>>(
-  ({ className, ...props }, ref) => {
-    return (
-      <main
-        ref={ref}
-        className={cn(
-          'relative flex w-full flex-1 flex-col bg-background',
-          'md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow',
-          className,
-        )}
-        {...props}
-      />
-    );
-  },
-);
-SidebarInset.displayName = 'SidebarInset';
-
-const SidebarInput = React.forwardRef<
-  React.ElementRef<typeof Input>,
-  React.ComponentProps<typeof Input>
->(({ className, ...props }, ref) => {
+function SidebarInset({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<'main'> & { ref?: React.Ref<HTMLDivElement> }) {
+  return (
+    <main
+      ref={ref}
+      className={cn(
+        'relative flex w-full flex-1 flex-col bg-background',
+        'md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+function SidebarInput({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<typeof Input> & { ref?: React.Ref<React.ElementRef<typeof Input>> }) {
   return (
     <Input
       ref={ref}
@@ -456,41 +438,42 @@ const SidebarInput = React.forwardRef<
       {...props}
     />
   );
-});
-SidebarInput.displayName = 'SidebarInput';
-
-const SidebarHeader = React.forwardRef<HTMLDivElement, React.ComponentProps<'div'>>(
-  ({ className, ...props }, ref) => {
-    return (
-      <div
-        ref={ref}
-        data-sidebar="header"
-        className={cn('flex flex-col gap-2 p-2', className)}
-        {...props}
-      />
-    );
-  },
-);
-SidebarHeader.displayName = 'SidebarHeader';
-
-const SidebarFooter = React.forwardRef<HTMLDivElement, React.ComponentProps<'div'>>(
-  ({ className, ...props }, ref) => {
-    return (
-      <div
-        ref={ref}
-        data-sidebar="footer"
-        className={cn('flex flex-col gap-2 p-2', className)}
-        {...props}
-      />
-    );
-  },
-);
-SidebarFooter.displayName = 'SidebarFooter';
-
-const SidebarSeparator = React.forwardRef<
-  React.ElementRef<typeof Separator>,
-  React.ComponentProps<typeof Separator>
->(({ className, ...props }, ref) => {
+}
+function SidebarHeader({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<'div'> & { ref?: React.Ref<HTMLDivElement> }) {
+  return (
+    <div
+      ref={ref}
+      data-sidebar="header"
+      className={cn('flex flex-col gap-2 p-2', className)}
+      {...props}
+    />
+  );
+}
+function SidebarFooter({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<'div'> & { ref?: React.Ref<HTMLDivElement> }) {
+  return (
+    <div
+      ref={ref}
+      data-sidebar="footer"
+      className={cn('flex flex-col gap-2 p-2', className)}
+      {...props}
+    />
+  );
+}
+function SidebarSeparator({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<typeof Separator> & {
+  ref?: React.Ref<React.ElementRef<typeof Separator>>;
+}) {
   return (
     <Separator
       ref={ref}
@@ -499,44 +482,44 @@ const SidebarSeparator = React.forwardRef<
       {...props}
     />
   );
-});
-SidebarSeparator.displayName = 'SidebarSeparator';
-
-const SidebarContent = React.forwardRef<HTMLDivElement, React.ComponentProps<'div'>>(
-  ({ className, ...props }, ref) => {
-    return (
-      <div
-        ref={ref}
-        data-sidebar="content"
-        className={cn(
-          'flex min-h-0 flex-1 flex-col overflow-auto group-data-[collapsible=icon]:overflow-hidden',
-          className,
-        )}
-        {...props}
-      />
-    );
-  },
-);
-SidebarContent.displayName = 'SidebarContent';
-
-const SidebarGroup = React.forwardRef<HTMLDivElement, React.ComponentProps<'div'>>(
-  ({ className, ...props }, ref) => {
-    return (
-      <div
-        ref={ref}
-        data-sidebar="group"
-        className={cn('relative flex w-full min-w-0 flex-col p-2', className)}
-        {...props}
-      />
-    );
-  },
-);
-SidebarGroup.displayName = 'SidebarGroup';
-
-const SidebarGroupLabel = React.forwardRef<
-  HTMLDivElement,
-  React.ComponentProps<'div'> & { asChild?: boolean }
->(({ className, asChild = false, ...props }, ref) => {
+}
+function SidebarContent({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<'div'> & { ref?: React.Ref<HTMLDivElement> }) {
+  return (
+    <div
+      ref={ref}
+      data-sidebar="content"
+      className={cn(
+        'flex min-h-0 flex-1 flex-col overflow-auto group-data-[collapsible=icon]:overflow-hidden',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+function SidebarGroup({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<'div'> & { ref?: React.Ref<HTMLDivElement> }) {
+  return (
+    <div
+      ref={ref}
+      data-sidebar="group"
+      className={cn('relative flex w-full min-w-0 flex-col p-2', className)}
+      {...props}
+    />
+  );
+}
+function SidebarGroupLabel({
+  className,
+  asChild = false,
+  ref,
+  ...props
+}: React.ComponentProps<'div'> & { asChild?: boolean } & { ref?: React.Ref<HTMLDivElement> }) {
   const Comp = asChild ? Slot : 'div';
 
   return (
@@ -551,13 +534,15 @@ const SidebarGroupLabel = React.forwardRef<
       {...props}
     />
   );
-});
-SidebarGroupLabel.displayName = 'SidebarGroupLabel';
-
-const SidebarGroupAction = React.forwardRef<
-  HTMLButtonElement,
-  React.ComponentProps<'button'> & { asChild?: boolean }
->(({ className, asChild = false, ...props }, ref) => {
+}
+function SidebarGroupAction({
+  className,
+  asChild = false,
+  ref,
+  ...props
+}: React.ComponentProps<'button'> & { asChild?: boolean } & {
+  ref?: React.Ref<HTMLButtonElement>;
+}) {
   const Comp = asChild ? Slot : 'button';
 
   return (
@@ -574,45 +559,49 @@ const SidebarGroupAction = React.forwardRef<
       {...props}
     />
   );
-});
-SidebarGroupAction.displayName = 'SidebarGroupAction';
-
-const SidebarGroupContent = React.forwardRef<HTMLDivElement, React.ComponentProps<'div'>>(
-  ({ className, ...props }, ref) => (
+}
+function SidebarGroupContent({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<'div'> & { ref?: React.Ref<HTMLDivElement> }) {
+  return (
     <div
       ref={ref}
       data-sidebar="group-content"
       className={cn('w-full text-sm', className)}
       {...props}
     />
-  ),
-);
-SidebarGroupContent.displayName = 'SidebarGroupContent';
-
-const SidebarMenu = React.forwardRef<HTMLUListElement, React.ComponentProps<'ul'>>(
-  ({ className, ...props }, ref) => (
+  );
+}
+function SidebarMenu({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<'ul'> & { ref?: React.Ref<HTMLUListElement> }) {
+  return (
     <ul
       ref={ref}
       data-sidebar="menu"
       className={cn('flex w-full min-w-0 flex-col gap-1', className)}
       {...props}
     />
-  ),
-);
-SidebarMenu.displayName = 'SidebarMenu';
-
-const SidebarMenuItem = React.forwardRef<HTMLLIElement, React.ComponentProps<'li'>>(
-  ({ className, ...props }, ref) => (
+  );
+}
+function SidebarMenuItem({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<'li'> & { ref?: React.Ref<HTMLLIElement> }) {
+  return (
     <li
       ref={ref}
       data-sidebar="menu-item"
       className={cn('group/menu-item relative', className)}
       {...props}
     />
-  ),
-);
-SidebarMenuItem.displayName = 'SidebarMenuItem';
-
+  );
+}
 const sidebarMenuButtonVariants = cva(
   'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-1 focus-visible:ring-sidebar-ring/50 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
   {
@@ -635,72 +624,66 @@ const sidebarMenuButtonVariants = cva(
   },
 );
 
-const SidebarMenuButton = React.forwardRef<
-  HTMLButtonElement,
-  React.ComponentProps<'button'> & {
-    asChild?: boolean;
-    isActive?: boolean;
-    tooltip?: string | React.ComponentProps<typeof TooltipContent>;
-  } & VariantProps<typeof sidebarMenuButtonVariants>
->(
-  (
-    {
-      asChild = false,
-      isActive = false,
-      variant = 'default',
-      size = 'default',
-      tooltip,
-      className,
-      ...props
-    },
-    ref,
-  ) => {
-    const Comp = asChild ? Slot : 'button';
-    const { isMobile, state } = useSidebar();
+function SidebarMenuButton({
+  asChild = false,
+  isActive = false,
+  variant = 'default',
+  size = 'default',
+  tooltip,
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<'button'> & {
+  asChild?: boolean;
+  isActive?: boolean;
+  tooltip?: string | React.ComponentProps<typeof TooltipContent>;
+} & VariantProps<typeof sidebarMenuButtonVariants> & { ref?: React.Ref<HTMLButtonElement> }) {
+  const Comp = asChild ? Slot : 'button';
+  const { isMobile, state } = useSidebar();
 
-    const button = (
-      <Comp
-        ref={ref}
-        data-sidebar="menu-button"
-        data-size={size}
-        data-active={isActive}
-        className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
-        {...props}
-      />
-    );
+  const button = (
+    <Comp
+      ref={ref}
+      data-sidebar="menu-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+      {...props}
+    />
+  );
 
-    if (!tooltip) {
-      return button;
-    }
-
-    if (typeof tooltip === 'string') {
-      tooltip = {
-        children: tooltip,
-      };
-    }
-
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild>{button}</TooltipTrigger>
-        <TooltipContent
-          side="right"
-          align="center"
-          hidden={state !== 'collapsed' || isMobile}
-          {...tooltip}
-        />
-      </Tooltip>
-    );
-  },
-);
-SidebarMenuButton.displayName = 'SidebarMenuButton';
-
-const SidebarMenuAction = React.forwardRef<
-  HTMLButtonElement,
-  React.ComponentProps<'button'> & {
-    asChild?: boolean;
-    showOnHover?: boolean;
+  if (!tooltip) {
+    return button;
   }
->(({ className, asChild = false, showOnHover = false, ...props }, ref) => {
+
+  if (typeof tooltip === 'string') {
+    tooltip = {
+      children: tooltip,
+    };
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent
+        side="right"
+        align="center"
+        hidden={state !== 'collapsed' || isMobile}
+        {...tooltip}
+      />
+    </Tooltip>
+  );
+}
+function SidebarMenuAction({
+  className,
+  asChild = false,
+  showOnHover = false,
+  ref,
+  ...props
+}: React.ComponentProps<'button'> & {
+  asChild?: boolean;
+  showOnHover?: boolean;
+} & { ref?: React.Ref<HTMLButtonElement> }) {
   const Comp = asChild ? Slot : 'button';
 
   return (
@@ -722,11 +705,13 @@ const SidebarMenuAction = React.forwardRef<
       {...props}
     />
   );
-});
-SidebarMenuAction.displayName = 'SidebarMenuAction';
-
-const SidebarMenuBadge = React.forwardRef<HTMLDivElement, React.ComponentProps<'div'>>(
-  ({ className, ...props }, ref) => (
+}
+function SidebarMenuBadge({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<'div'> & { ref?: React.Ref<HTMLDivElement> }) {
+  return (
     <div
       ref={ref}
       data-sidebar="menu-badge"
@@ -741,16 +726,16 @@ const SidebarMenuBadge = React.forwardRef<HTMLDivElement, React.ComponentProps<'
       )}
       {...props}
     />
-  ),
-);
-SidebarMenuBadge.displayName = 'SidebarMenuBadge';
-
-const SidebarMenuSkeleton = React.forwardRef<
-  HTMLDivElement,
-  React.ComponentProps<'div'> & {
-    showIcon?: boolean;
-  }
->(({ className, showIcon = false, ...props }, ref) => {
+  );
+}
+function SidebarMenuSkeleton({
+  className,
+  showIcon = false,
+  ref,
+  ...props
+}: React.ComponentProps<'div'> & {
+  showIcon?: boolean;
+} & { ref?: React.Ref<HTMLDivElement> }) {
   // Random width between 50 to 90%.
   const width = React.useMemo(() => {
     return `${Math.floor(Math.random() * 40) + 50}%`;
@@ -775,11 +760,13 @@ const SidebarMenuSkeleton = React.forwardRef<
       />
     </div>
   );
-});
-SidebarMenuSkeleton.displayName = 'SidebarMenuSkeleton';
-
-const SidebarMenuSub = React.forwardRef<HTMLUListElement, React.ComponentProps<'ul'>>(
-  ({ className, ...props }, ref) => (
+}
+function SidebarMenuSub({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<'ul'> & { ref?: React.Ref<HTMLUListElement> }) {
+  return (
     <ul
       ref={ref}
       data-sidebar="menu-sub"
@@ -790,23 +777,26 @@ const SidebarMenuSub = React.forwardRef<HTMLUListElement, React.ComponentProps<'
       )}
       {...props}
     />
-  ),
-);
-SidebarMenuSub.displayName = 'SidebarMenuSub';
-
-const SidebarMenuSubItem = React.forwardRef<HTMLLIElement, React.ComponentProps<'li'>>(
-  ({ ...props }, ref) => <li ref={ref} {...props} />,
-);
-SidebarMenuSubItem.displayName = 'SidebarMenuSubItem';
-
-const SidebarMenuSubButton = React.forwardRef<
-  HTMLAnchorElement,
-  React.ComponentProps<'a'> & {
-    asChild?: boolean;
-    size?: 'sm' | 'md';
-    isActive?: boolean;
-  }
->(({ asChild = false, size = 'md', isActive, className, ...props }, ref) => {
+  );
+}
+function SidebarMenuSubItem({
+  ref,
+  ...props
+}: React.ComponentProps<'li'> & { ref?: React.Ref<HTMLLIElement> }) {
+  return <li ref={ref} {...props} />;
+}
+function SidebarMenuSubButton({
+  asChild = false,
+  size = 'md',
+  isActive,
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<'a'> & {
+  asChild?: boolean;
+  size?: 'sm' | 'md';
+  isActive?: boolean;
+} & { ref?: React.Ref<HTMLAnchorElement> }) {
   const Comp = asChild ? Slot : 'a';
 
   return (
@@ -826,9 +816,7 @@ const SidebarMenuSubButton = React.forwardRef<
       {...props}
     />
   );
-});
-SidebarMenuSubButton.displayName = 'SidebarMenuSubButton';
-
+}
 export {
   Sidebar,
   SidebarContent,

--- a/packages/client/src/components/ui/switch.tsx
+++ b/packages/client/src/components/ui/switch.tsx
@@ -3,21 +3,24 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
-const Switch = React.forwardRef<
-  React.ElementRef<typeof SwitchPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
->(({ className, ...props }, ref) => (
-  <SwitchPrimitives.Root
-    className={cn(
-      'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
-      className,
-    )}
-    {...props}
-    ref={ref}
-  >
-    <SwitchPrimitives.Thumb className="pointer-events-none block size-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0" />
-  </SwitchPrimitives.Root>
-));
-Switch.displayName = SwitchPrimitives.Root.displayName;
-
+function Switch({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> & {
+  ref?: React.Ref<React.ElementRef<typeof SwitchPrimitives.Root>>;
+}) {
+  return (
+    <SwitchPrimitives.Root
+      className={cn(
+        'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+        className,
+      )}
+      {...props}
+      ref={ref}
+    >
+      <SwitchPrimitives.Thumb className="pointer-events-none block size-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0" />
+    </SwitchPrimitives.Root>
+  );
+}
 export { Switch };

--- a/packages/client/src/components/ui/tabs.tsx
+++ b/packages/client/src/components/ui/tabs.tsx
@@ -5,49 +5,58 @@ import { cn } from '@/lib/utils';
 
 const Tabs = TabsPrimitive.Root;
 
-const TabsList = React.forwardRef<
-  React.ComponentRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.List
-    ref={ref}
-    className={cn(
-      'inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground',
-      className,
-    )}
-    {...props}
-  />
-));
-TabsList.displayName = TabsPrimitive.List.displayName;
-
-const TabsTrigger = React.forwardRef<
-  React.ComponentRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-xs font-medium transition-all hover:bg-muted-foreground/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow',
-      className,
-    )}
-    {...props}
-  />
-));
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
-
-const TabsContent = React.forwardRef<
-  React.ComponentRef<typeof TabsPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Content
-    ref={ref}
-    className={cn(
-      'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50',
-      className,
-    )}
-    {...props}
-  />
-));
-TabsContent.displayName = TabsPrimitive.Content.displayName;
-
+function TabsList({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof TabsPrimitive.List> & {
+  ref?: React.Ref<React.ComponentRef<typeof TabsPrimitive.List>>;
+}) {
+  return (
+    <TabsPrimitive.List
+      ref={ref}
+      className={cn(
+        'inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+function TabsTrigger({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> & {
+  ref?: React.Ref<React.ComponentRef<typeof TabsPrimitive.Trigger>>;
+}) {
+  return (
+    <TabsPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-xs font-medium transition-all hover:bg-muted-foreground/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+function TabsContent({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content> & {
+  ref?: React.Ref<React.ComponentRef<typeof TabsPrimitive.Content>>;
+}) {
+  return (
+    <TabsPrimitive.Content
+      ref={ref}
+      className={cn(
+        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/packages/client/src/components/ui/textarea.tsx
+++ b/packages/client/src/components/ui/textarea.tsx
@@ -22,11 +22,12 @@ const textareaVariants = cva(
 export interface TextareaProps
   extends Omit<React.ComponentProps<'textarea'>, 'size'>, VariantProps<typeof textareaVariants> {}
 
-const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, size, ...props }, ref) => {
-    return <textarea className={cn(textareaVariants({ size }), className)} ref={ref} {...props} />;
-  },
-);
-Textarea.displayName = 'Textarea';
-
+function Textarea({
+  className,
+  size,
+  ref,
+  ...props
+}: TextareaProps & { ref?: React.Ref<HTMLTextAreaElement> }) {
+  return <textarea className={cn(textareaVariants({ size }), className)} ref={ref} {...props} />;
+}
 export { Textarea, textareaVariants };

--- a/packages/client/src/components/ui/toggle-group.tsx
+++ b/packages/client/src/components/ui/toggle-group.tsx
@@ -10,27 +10,40 @@ const ToggleGroupContext = React.createContext<VariantProps<typeof toggleVariant
   variant: 'default',
 });
 
-const ToggleGroup = React.forwardRef<
-  React.ComponentRef<typeof ToggleGroupPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
-    VariantProps<typeof toggleVariants>
->(({ className, variant, size, children, ...props }, ref) => (
-  <ToggleGroupPrimitive.Root
-    ref={ref}
-    className={cn('flex items-center justify-center gap-1', className)}
-    {...props}
-  >
-    <ToggleGroupContext.Provider value={{ variant, size }}>{children}</ToggleGroupContext.Provider>
-  </ToggleGroupPrimitive.Root>
-));
-
-ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName;
-
-const ToggleGroupItem = React.forwardRef<
-  React.ComponentRef<typeof ToggleGroupPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
-    VariantProps<typeof toggleVariants>
->(({ className, children, variant, size, ...props }, ref) => {
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants> & {
+    ref?: React.Ref<React.ComponentRef<typeof ToggleGroupPrimitive.Root>>;
+  }) {
+  return (
+    <ToggleGroupPrimitive.Root
+      ref={ref}
+      className={cn('flex items-center justify-center gap-1', className)}
+      {...props}
+    >
+      <ToggleGroupContext.Provider value={{ variant, size }}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  );
+}
+function ToggleGroupItem({
+  className,
+  children,
+  variant,
+  size,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
+  VariantProps<typeof toggleVariants> & {
+    ref?: React.Ref<React.ComponentRef<typeof ToggleGroupPrimitive.Item>>;
+  }) {
   const context = React.useContext(ToggleGroupContext);
 
   return (
@@ -48,8 +61,5 @@ const ToggleGroupItem = React.forwardRef<
       {children}
     </ToggleGroupPrimitive.Item>
   );
-});
-
-ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName;
-
+}
 export { ToggleGroup, ToggleGroupItem };

--- a/packages/client/src/components/ui/toggle.tsx
+++ b/packages/client/src/components/ui/toggle.tsx
@@ -26,17 +26,22 @@ const toggleVariants = cva(
   },
 );
 
-const Toggle = React.forwardRef<
-  React.ComponentRef<typeof TogglePrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> & VariantProps<typeof toggleVariants>
->(({ className, variant, size, ...props }, ref) => (
-  <TogglePrimitive.Root
-    ref={ref}
-    className={cn(toggleVariants({ variant, size, className }))}
-    {...props}
-  />
-));
-
-Toggle.displayName = TogglePrimitive.Root.displayName;
-
+function Toggle({
+  className,
+  variant,
+  size,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
+  VariantProps<typeof toggleVariants> & {
+    ref?: React.Ref<React.ComponentRef<typeof TogglePrimitive.Root>>;
+  }) {
+  return (
+    <TogglePrimitive.Root
+      ref={ref}
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
 export { Toggle, toggleVariants };

--- a/packages/client/src/components/ui/tooltip-icon-button.tsx
+++ b/packages/client/src/components/ui/tooltip-icon-button.tsx
@@ -16,34 +16,36 @@ export interface TooltipIconButtonProps extends Omit<ButtonProps, 'children'> {
  * A Button wrapped with a Tooltip. Automatically handles the disabled-button
  * case by inserting a `<span>` wrapper so the tooltip still shows on hover.
  */
-const TooltipIconButton = React.forwardRef<HTMLButtonElement, TooltipIconButtonProps>(
-  (
-    { tooltip, children, variant = 'ghost', size = 'icon-xs', className, disabled, ...props },
-    ref,
-  ) => {
-    const button = (
-      <Button
-        ref={disabled ? undefined : ref}
-        variant={variant}
-        size={size}
-        className={cn(className)}
-        disabled={disabled}
-        {...props}
-      >
-        {children}
-      </Button>
-    );
+function TooltipIconButton({
+  tooltip,
+  children,
+  variant = 'ghost',
+  size = 'icon-xs',
+  className,
+  disabled,
+  ref,
+  ...props
+}: TooltipIconButtonProps & { ref?: React.Ref<HTMLButtonElement> }) {
+  const button = (
+    <Button
+      ref={disabled ? undefined : ref}
+      variant={variant}
+      size={size}
+      className={cn(className)}
+      disabled={disabled}
+      {...props}
+    >
+      {children}
+    </Button>
+  );
 
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          {disabled ? <span ref={ref as React.Ref<HTMLSpanElement>}>{button}</span> : button}
-        </TooltipTrigger>
-        <TooltipContent>{tooltip}</TooltipContent>
-      </Tooltip>
-    );
-  },
-);
-TooltipIconButton.displayName = 'TooltipIconButton';
-
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        {disabled ? <span ref={ref as React.Ref<HTMLSpanElement>}>{button}</span> : button}
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}
 export { TooltipIconButton };

--- a/packages/client/src/components/ui/tooltip.tsx
+++ b/packages/client/src/components/ui/tooltip.tsx
@@ -7,41 +7,48 @@ const TooltipProvider = TooltipPrimitive.Provider;
 
 const Tooltip = TooltipPrimitive.Root;
 
-const TooltipTrigger = React.forwardRef<
-  React.ElementRef<typeof TooltipPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Trigger>
->(({ onFocusCapture, ...props }, ref) => (
-  <TooltipPrimitive.Trigger
-    ref={ref}
-    onFocusCapture={(event) => {
-      onFocusCapture?.(event);
-      if (event.defaultPrevented || event.isPropagationStopped()) return;
-      const target = event.target as HTMLElement | null;
-      if (target && typeof target.matches === 'function' && !target.matches(':focus-visible')) {
-        event.stopPropagation();
-      }
-    }}
-    {...props}
-  />
-));
-TooltipTrigger.displayName = TooltipPrimitive.Trigger.displayName;
-
-const TooltipContent = React.forwardRef<
-  React.ElementRef<typeof TooltipPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Portal>
-    <TooltipPrimitive.Content
+function TooltipTrigger({
+  onFocusCapture,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Trigger> & {
+  ref?: React.Ref<React.ElementRef<typeof TooltipPrimitive.Trigger>>;
+}) {
+  return (
+    <TooltipPrimitive.Trigger
       ref={ref}
-      sideOffset={sideOffset}
-      className={cn(
-        'z-50 rounded-md border border-white/20 bg-white px-2 py-1 text-xs text-gray-900 shadow-md animate-in fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0',
-        className,
-      )}
+      onFocusCapture={(event) => {
+        onFocusCapture?.(event);
+        if (event.defaultPrevented || event.isPropagationStopped()) return;
+        const target = event.target as HTMLElement | null;
+        if (target && typeof target.matches === 'function' && !target.matches(':focus-visible')) {
+          event.stopPropagation();
+        }
+      }}
       {...props}
     />
-  </TooltipPrimitive.Portal>
-));
-TooltipContent.displayName = TooltipPrimitive.Content.displayName;
-
+  );
+}
+function TooltipContent({
+  className,
+  sideOffset = 4,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content> & {
+  ref?: React.Ref<React.ElementRef<typeof TooltipPrimitive.Content>>;
+}) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        ref={ref}
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 rounded-md border border-white/20 bg-white px-2 py-1 text-xs text-gray-900 shadow-md animate-in fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0',
+          className,
+        )}
+        {...props}
+      />
+    </TooltipPrimitive.Portal>
+  );
+}
 export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/packages/client/src/components/virtual-diff/DiffMinimap.tsx
+++ b/packages/client/src/components/virtual-diff/DiffMinimap.tsx
@@ -119,8 +119,8 @@ export const DiffMinimap = memo(function DiffMinimap({
     };
   }, [scrollElement, totalSize, containerHeight]);
 
-  // Handle click → scroll to position
-  const handleClick = useCallback(
+  // Click on minimap → scroll the viewport to that vertical position
+  const scrollToClick = useCallback(
     (e: React.MouseEvent) => {
       if (!scrollElement || containerHeight === 0) return;
       const rect = e.currentTarget.getBoundingClientRect();
@@ -168,7 +168,7 @@ export const DiffMinimap = memo(function DiffMinimap({
       ref={containerRef}
       className="relative flex-shrink-0 cursor-pointer border-l border-border/50 bg-muted/20"
       style={{ width: MINIMAP_WIDTH }}
-      onClick={handleClick}
+      onClick={scrollToClick}
       data-testid="diff-minimap"
     >
       <canvas ref={canvasRef} className="block" />

--- a/packages/client/src/hooks/use-notifications.ts
+++ b/packages/client/src/hooks/use-notifications.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { createClientLogger } from '@/lib/client-logger';
 import { useSettingsStore } from '@/stores/settings-store';
@@ -131,10 +131,6 @@ export function showAgentNotification(
  */
 export function useNotifications() {
   const [permission, setPermission] = useState<NotificationPermissionState>(readPermission);
-
-  useEffect(() => {
-    setPermission(readPermission());
-  }, []);
 
   const requestPermission = useCallback(async (): Promise<NotificationPermissionState> => {
     if (!isNotificationsSupported()) return 'unsupported';

--- a/packages/client/src/hooks/use-preview-window.ts
+++ b/packages/client/src/hooks/use-preview-window.ts
@@ -20,19 +20,20 @@ if (isTauri && !isPreviewWindow) {
   (async () => {
     const { listen, emit } = await import('@tauri-apps/api/event');
 
-    // When the preview window signals it's ready, sync all current tabs
-    await listen('preview:ready', () => {
-      const store = usePreviewStore.getState();
-      for (const tab of store.tabs) {
-        emit('preview:add-tab', tab);
-      }
-    });
-
-    // When the preview window closes a tab, update the main store
-    await listen<{ commandId: string }>('preview:tab-closed', (e) => {
-      const store = usePreviewStore.getState();
-      store.removeTab(e.payload.commandId);
-    });
+    await Promise.all([
+      // When the preview window signals it's ready, sync all current tabs
+      listen('preview:ready', () => {
+        const store = usePreviewStore.getState();
+        for (const tab of store.tabs) {
+          emit('preview:add-tab', tab);
+        }
+      }),
+      // When the preview window closes a tab, update the main store
+      listen<{ commandId: string }>('preview:tab-closed', (e) => {
+        const store = usePreviewStore.getState();
+        store.removeTab(e.payload.commandId);
+      }),
+    ]);
   })();
 }
 

--- a/packages/client/src/lib/drag-preview.ts
+++ b/packages/client/src/lib/drag-preview.ts
@@ -1,0 +1,29 @@
+import { setCustomNativeDragPreview } from '@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview';
+
+interface DashedPreviewArgs {
+  nativeSetDragImage: ((image: Element, x: number, y: number) => void) | null;
+  source: HTMLElement;
+}
+
+export function setDashedDragPreview({ nativeSetDragImage, source }: DashedPreviewArgs) {
+  setCustomNativeDragPreview({
+    nativeSetDragImage,
+    getOffset: () => ({ x: 16, y: 16 }),
+    render: ({ container }) => {
+      const rect = source.getBoundingClientRect();
+      const styles = getComputedStyle(source);
+      const primary = styles.getPropertyValue('--primary').trim() || '240 5.9% 10%';
+      const background = styles.getPropertyValue('--background').trim() || '0 0% 100%';
+      const preview = document.createElement('div');
+      preview.style.cssText = [
+        `width:${Math.max(rect.width, 80)}px`,
+        `height:${Math.max(rect.height, 40)}px`,
+        'border-radius:8px',
+        `border:2px dashed hsl(${primary})`,
+        `background:hsl(${background})`,
+        `box-shadow:0 4px 12px hsl(${primary} / 0.25)`,
+      ].join(';');
+      container.appendChild(preview);
+    },
+  });
+}

--- a/packages/client/src/lib/render-items.ts
+++ b/packages/client/src/lib/render-items.ts
@@ -13,22 +13,23 @@ const NO_GROUP = new Set(['AskUserQuestion', 'ExitPlanMode']);
 export function groupConsecutiveToolCalls(items: { tc: any }[]): ToolItem[] {
   const grouped: ToolItem[] = [];
   for (const item of items) {
+    const { tc } = item;
     const last = grouped[grouped.length - 1];
-    if (!NO_GROUP.has(item.tc.name)) {
-      if (last?.type === 'toolcall' && last.tc.name === item.tc.name) {
+    if (!NO_GROUP.has(tc.name)) {
+      if (last?.type === 'toolcall' && last.tc.name === tc.name) {
         grouped[grouped.length - 1] = {
           type: 'toolcall-group',
-          name: item.tc.name,
-          calls: [last.tc, item.tc],
+          name: tc.name,
+          calls: [last.tc, tc],
         };
         continue;
       }
-      if (last?.type === 'toolcall-group' && last.name === item.tc.name) {
-        last.calls.push(item.tc);
+      if (last?.type === 'toolcall-group' && last.name === tc.name) {
+        last.calls.push(tc);
         continue;
       }
     }
-    grouped.push({ type: 'toolcall', tc: item.tc });
+    grouped.push({ type: 'toolcall', tc });
   }
   return grouped;
 }

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -17,6 +17,7 @@ window.addEventListener(
   },
   true,
 );
+import { domAnimation, LazyMotion } from 'motion/react';
 import { ThemeProvider, useTheme } from 'next-themes';
 import React, { lazy, Suspense, useEffect, useState, useSyncExternalStore } from 'react';
 import ReactDOM from 'react-dom/client';
@@ -261,13 +262,15 @@ root.render(
         }}
       >
         <TooltipProvider delayDuration={300} skipDelayDuration={0}>
-          {isPreviewWindow ? (
-            <Suspense fallback={null}>
-              <PreviewBrowser />
-            </Suspense>
-          ) : (
-            <AuthGate />
-          )}
+          <LazyMotion features={domAnimation} strict>
+            {isPreviewWindow ? (
+              <Suspense fallback={null}>
+                <PreviewBrowser />
+              </Suspense>
+            ) : (
+              <AuthGate />
+            )}
+          </LazyMotion>
         </TooltipProvider>
       </AbbacchioProvider>
     </ThemeProvider>

--- a/packages/client/src/stores/app-store.ts
+++ b/packages/client/src/stores/app-store.ts
@@ -90,50 +90,50 @@ export function useAppStore<T>(selector: (state: CombinedState) => T): T {
 // Imperative getState() for use-ws.ts and use-route-sync.ts
 useAppStore.getState = getCombinedState;
 
+const PROJECT_KEYS = new Set([
+  'projects',
+  'expandedProjects',
+  'selectedProjectId',
+  'initialized',
+  'loadProjects',
+  'toggleProject',
+  'selectProject',
+  'deleteProject',
+  'reorderProjects',
+  'renameProject',
+]);
+const THREAD_KEYS = new Set([
+  'threadsByProject',
+  'selectedThreadId',
+  'activeThread',
+  'loadThreadsForProject',
+  'selectThread',
+  'archiveThread',
+  'pinThread',
+  'deleteThread',
+  'appendOptimisticMessage',
+  'refreshActiveThread',
+  'refreshAllLoadedThreads',
+  'clearProjectThreads',
+  'handleWSInit',
+  'handleWSMessage',
+  'handleWSToolCall',
+  'handleWSToolOutput',
+  'handleWSStatus',
+  'handleWSResult',
+  'handleWSQueueUpdate',
+]);
+
 // setState support for tests
 useAppStore.setState = (partial: Partial<CombinedState>) => {
-  const projectKeys = [
-    'projects',
-    'expandedProjects',
-    'selectedProjectId',
-    'initialized',
-    'loadProjects',
-    'toggleProject',
-    'selectProject',
-    'deleteProject',
-    'reorderProjects',
-    'renameProject',
-  ];
-  const threadKeys = [
-    'threadsByProject',
-    'selectedThreadId',
-    'activeThread',
-    'loadThreadsForProject',
-    'selectThread',
-    'archiveThread',
-    'pinThread',
-    'deleteThread',
-    'appendOptimisticMessage',
-    'refreshActiveThread',
-    'refreshAllLoadedThreads',
-    'clearProjectThreads',
-    'handleWSInit',
-    'handleWSMessage',
-    'handleWSToolCall',
-    'handleWSToolOutput',
-    'handleWSStatus',
-    'handleWSResult',
-    'handleWSQueueUpdate',
-  ];
-
   const projectPartial: Record<string, any> = {};
   const threadPartial: Record<string, any> = {};
   const uiPartial: Record<string, any> = {};
 
   for (const [key, value] of Object.entries(partial)) {
-    if (projectKeys.includes(key)) {
+    if (PROJECT_KEYS.has(key)) {
       projectPartial[key] = value;
-    } else if (threadKeys.includes(key)) {
+    } else if (THREAD_KEYS.has(key)) {
       threadPartial[key] = value;
     } else {
       uiPartial[key] = value;


### PR DESCRIPTION
## Summary

- Replace `motion.*` with `m.*` (lazy motion) across animated components — better tree-shaking / smaller bundle
- Extract dashed drag preview logic into `lib/drag-preview.ts` shared by sidebar, kanban, and thread column draggables
- Expand `SlideUpPrompt` / `KanbanView` submit opts with `provider`, `effort`, `runtime`, `fileReferences`, `symbolReferences`, `agentTemplateId`, and `templateVariables`
- Use `Set.has()` instead of `Array.includes()` for O(1) status checks in `RecentThreads`
- Hoist stable array/object defaults to module-level constants to prevent spurious re-renders (`ThreadPickerDialog`, `BranchPicker`)
- Extract `PLAYWRIGHT_SNIPPETS` constant and refactor `CallTab` filter with `.some()`
- Minor: `font-bold` → `font-semibold` on headings, `bg-black` → `bg-gray-950` for video background

## Test plan

- [ ] Verify animated components (D4CAnimation, WorktreeSetupProgress, MessageStream) still animate correctly
- [ ] Drag a thread card in kanban and sidebar — confirm dashed preview appears
- [ ] Run unit tests: `cd packages/client && bunx vitest run --project unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)