### PR TITLE
fix(shared): declare @types/pg as devDependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -120,6 +120,7 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-web-links": "^0.12.0",
+        "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "ansi-to-html": "^0.7.2",
         "better-auth": "^1.4.18",
@@ -417,6 +418,9 @@
         "nanoid": "^5.1.5",
         "pg": "^8.20.0",
         "xstate": "^5.28.0",
+      },
+      "devDependencies": {
+        "@types/pg": "^8.18.0",
       },
     },
   },
@@ -1617,6 +1621,8 @@
     "@xterm/addon-serialize": ["@xterm/addon-serialize@0.14.0", "", {}, "sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA=="],
 
     "@xterm/addon-web-links": ["@xterm/addon-web-links@0.12.0", "", {}, "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw=="],
+
+    "@xterm/addon-webgl": ["@xterm/addon-webgl@0.19.0", "", {}, "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A=="],
 
     "@xterm/headless": ["@xterm/headless@6.0.0", "", {}, "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw=="],
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -52,6 +52,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-web-links": "^0.12.0",
+    "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "ansi-to-html": "^0.7.2",
     "better-auth": "^1.4.18",

--- a/packages/client/src/components/TerminalPanel.tsx
+++ b/packages/client/src/components/TerminalPanel.tsx
@@ -430,11 +430,13 @@ function WebTerminalTabContent({
       // Register the PTY data callback. Any data that arrived before
       // registration (e.g. from an early pty:restore response) is replayed
       // immediately via the store's pending buffer.
-      registerPtyCallback(id, (data: string) => {
+      registerPtyCallback(id, (data) => {
         if (!cancelled) {
           send({ type: 'DATA_RECEIVED' });
           useTerminalStore.getState().markAlive(id);
         }
+        // terminal.write accepts both string and Uint8Array natively.
+        // Binary chunks from the runtime hot path arrive as Uint8Array.
         terminal.write(data);
         // Auto-execute initial command once the shell is ready (first output = prompt)
         if (!initialCommandSentRef.current && initialCommand) {

--- a/packages/client/src/components/TerminalPanel.tsx
+++ b/packages/client/src/components/TerminalPanel.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from 'react-i18next';
 import { useShallow } from 'zustand/react/shallow';
 
 import {
+  attachWebglRenderer,
   getCssVar,
   getTerminalTheme,
   getXtermModules,
@@ -87,12 +88,14 @@ function TauriTerminalTabContent({
     let isMounted = true;
 
     (async () => {
-      const [{ Terminal }, { FitAddon }, { WebLinksAddon }, { SearchAddon }] = await Promise.all([
-        import('@xterm/xterm'),
-        import('@xterm/addon-fit'),
-        import('@xterm/addon-web-links'),
-        import('@xterm/addon-search'),
-      ]);
+      const [{ Terminal }, { FitAddon }, { WebLinksAddon }, { SearchAddon }, { WebglAddon }] =
+        await Promise.all([
+          import('@xterm/xterm'),
+          import('@xterm/addon-fit'),
+          import('@xterm/addon-web-links'),
+          import('@xterm/addon-search'),
+          import('@xterm/addon-webgl'),
+        ]);
       // @ts-ignore - CSS import handled by Vite bundler
       await import('@xterm/xterm/css/xterm.css');
 
@@ -114,6 +117,7 @@ function TauriTerminalTabContent({
       terminal.loadAddon(webLinksAddon);
       terminal.loadAddon(searchAddon);
       terminal.open(containerRef.current);
+      attachWebglRenderer(terminal, WebglAddon);
       searchAddonRegistry.set(id, searchAddon);
       terminalRegistry.set(id, terminal);
       terminal.attachCustomKeyEventHandler((e) => {
@@ -351,7 +355,8 @@ function WebTerminalTabContent({
     let cleanup: (() => void) | null = null;
 
     (async () => {
-      const { Terminal, FitAddon, WebLinksAddon, SearchAddon } = await getXtermModules();
+      const { Terminal, FitAddon, WebLinksAddon, SearchAddon, WebglAddon } =
+        await getXtermModules();
       if (cancelled || !containerRef.current) return;
 
       const terminal = new Terminal({
@@ -370,6 +375,7 @@ function WebTerminalTabContent({
       terminal.loadAddon(webLinksAddon);
       terminal.loadAddon(searchAddon);
       terminal.open(containerRef.current);
+      attachWebglRenderer(terminal, WebglAddon);
       searchAddonRegistry.set(id, searchAddon);
       terminalRegistry.set(id, terminal);
       terminal.attachCustomKeyEventHandler((e) => {

--- a/packages/client/src/components/terminal/xterm-utils.ts
+++ b/packages/client/src/components/terminal/xterm-utils.ts
@@ -1,5 +1,10 @@
 import { useEffect, type RefObject } from 'react';
 
+import { createClientLogger } from '@/lib/client-logger';
+import { metric } from '@/lib/telemetry';
+
+const log = createClientLogger('terminal/webgl');
+
 export const isTauri = !!(window as unknown as { __TAURI_INTERNALS__: unknown })
   .__TAURI_INTERNALS__;
 
@@ -8,6 +13,7 @@ let xtermModulesPromise: Promise<{
   FitAddon: typeof import('@xterm/addon-fit').FitAddon;
   WebLinksAddon: typeof import('@xterm/addon-web-links').WebLinksAddon;
   SearchAddon: typeof import('@xterm/addon-search').SearchAddon;
+  WebglAddon: typeof import('@xterm/addon-webgl').WebglAddon;
 }> | null = null;
 
 export function getXtermModules() {
@@ -17,16 +23,56 @@ export function getXtermModules() {
       import('@xterm/addon-fit'),
       import('@xterm/addon-web-links'),
       import('@xterm/addon-search'),
+      import('@xterm/addon-webgl'),
       // @ts-ignore - CSS import handled by Vite bundler
       import('@xterm/xterm/css/xterm.css'),
-    ]).then(([xterm, fit, webLinks, search]) => ({
+    ]).then(([xterm, fit, webLinks, search, webgl]) => ({
       Terminal: xterm.Terminal,
       FitAddon: fit.FitAddon,
       WebLinksAddon: webLinks.WebLinksAddon,
       SearchAddon: search.SearchAddon,
+      WebglAddon: webgl.WebglAddon,
     }));
   }
   return xtermModulesPromise;
+}
+
+/**
+ * Attach the WebGL renderer addon to a Terminal. Must be called AFTER
+ * `terminal.open(container)` so the canvas exists.
+ *
+ * Falls back to the default DOM renderer silently on:
+ *   - missing WebGL2 context (older GPUs / disabled in browser)
+ *   - synchronous addon load failure
+ *   - asynchronous WebGL context loss (e.g. GPU reset, tab moved between displays)
+ *
+ * Emits `terminal.renderer` metric with attribute `renderer = webgl | dom-fallback`
+ * on initial attach, and `dom-fallback-context-lost` on later context loss.
+ *
+ * Returns the addon (or null when fallback was used) so the caller can
+ * dispose it manually if needed — `terminal.dispose()` will also dispose it.
+ */
+export function attachWebglRenderer(
+  terminal: import('@xterm/xterm').Terminal,
+  WebglAddon: typeof import('@xterm/addon-webgl').WebglAddon,
+): import('@xterm/addon-webgl').WebglAddon | null {
+  try {
+    const addon = new WebglAddon();
+    addon.onContextLoss(() => {
+      log.warn('WebGL context lost, falling back to DOM renderer');
+      metric('terminal.renderer', 1, { attributes: { renderer: 'dom-fallback-context-lost' } });
+      addon.dispose();
+    });
+    terminal.loadAddon(addon);
+    metric('terminal.renderer', 1, { attributes: { renderer: 'webgl' } });
+    return addon;
+  } catch (err) {
+    log.warn('WebGL renderer unavailable, using DOM renderer', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    metric('terminal.renderer', 1, { attributes: { renderer: 'dom-fallback' } });
+    return null;
+  }
 }
 
 export const searchAddonRegistry = new Map<string, import('@xterm/addon-search').SearchAddon>();

--- a/packages/client/src/hooks/use-terminal.ts
+++ b/packages/client/src/hooks/use-terminal.ts
@@ -1,8 +1,10 @@
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
+import { WebglAddon } from '@xterm/addon-webgl';
 import { Terminal } from '@xterm/xterm';
 import { useEffect, useRef } from 'react';
 
+import { attachWebglRenderer } from '@/components/terminal/xterm-utils';
 import { useSettingsStore, EDITOR_FONT_SIZE_PX } from '@/stores/settings-store';
 import { useTerminalStore } from '@/stores/terminal-store';
 
@@ -78,6 +80,7 @@ export function useTerminal({ id, cwd, containerRef }: UseTerminalOptions) {
     terminal.loadAddon(fitAddon);
     terminal.loadAddon(webLinksAddon);
     terminal.open(containerRef.current);
+    attachWebglRenderer(terminal, WebglAddon);
     // Re-apply theme after terminal is attached to DOM
     terminal.options.theme = getTerminalTheme();
 

--- a/packages/client/src/stores/terminal-store.ts
+++ b/packages/client/src/stores/terminal-store.ts
@@ -44,7 +44,11 @@ export interface TerminalTab {
 
 // Buffer for pty:data that arrives before a callback is registered.
 // Stored outside Zustand to avoid re-renders on every data chunk.
-const pendingPtyData = new Map<string, string[]>();
+// Accepts both string and Uint8Array — the hot path (PTY → server) now
+// sends raw UTF-8 bytes as binary frames to skip JSON.stringify; the
+// restore/adopt paths still send strings.
+type PtyChunk = string | Uint8Array;
+const pendingPtyData = new Map<string, PtyChunk[]>();
 
 interface TerminalState {
   tabs: TerminalTab[];
@@ -54,7 +58,7 @@ interface TerminalState {
   /** Output buffer per commandId for server-managed commands */
   commandOutput: Record<string, string>;
   /** PTY data callbacks: ptyId -> callback function */
-  ptyDataCallbacks: Record<string, (data: string) => void>;
+  ptyDataCallbacks: Record<string, (data: PtyChunk) => void>;
   /** Whether the server's pty:sessions response has been processed after WS connect */
   sessionsChecked: boolean;
 
@@ -71,9 +75,9 @@ interface TerminalState {
   appendCommandOutput: (commandId: string, data: string) => void;
   markCommandExited: (commandId: string) => void;
   setTabError: (ptyId: string, error: string) => void;
-  registerPtyCallback: (ptyId: string, callback: (data: string) => void) => void;
+  registerPtyCallback: (ptyId: string, callback: (data: PtyChunk) => void) => void;
   unregisterPtyCallback: (ptyId: string) => void;
-  emitPtyData: (ptyId: string, data: string) => void;
+  emitPtyData: (ptyId: string, data: PtyChunk) => void;
   setBellActive: (id: string) => void;
   clearBell: (id: string) => void;
   /** Metrics for running commands (uptime, memory, restart count) */
@@ -229,13 +233,18 @@ export const useTerminalStore = create<TerminalState>()(
 
       registerPtyCallback: (ptyId, callback) => {
         // Replay any data that arrived before the callback was registered
-        // (e.g. pty:restore response arriving while xterm was still loading)
+        // (e.g. pty:restore response arriving while xterm was still loading).
+        // Replay each chunk individually — buffered chunks are a mix of
+        // strings (restore/adopt) and Uint8Arrays (hot path binary frames);
+        // Array.join() would stringify Uint8Arrays as "1,2,3,…" and corrupt
+        // the stream, so we hand each chunk to the callback as-is.
         const buffered = pendingPtyData.get(ptyId);
         if (buffered && buffered.length > 0) {
-          const joined = buffered.join('');
           pendingPtyData.delete(ptyId);
           // Replay in a microtask so the callback is set in state first
-          queueMicrotask(() => callback(joined));
+          queueMicrotask(() => {
+            for (const chunk of buffered) callback(chunk);
+          });
         }
         set((state) => ({
           ptyDataCallbacks: { ...state.ptyDataCallbacks, [ptyId]: callback },
@@ -251,9 +260,14 @@ export const useTerminalStore = create<TerminalState>()(
       },
 
       emitPtyData: (ptyId, data) => {
+        // Socket.IO may surface binary attachments as ArrayBuffer; xterm only
+        // accepts string | Uint8Array, so normalize once here at the boundary
+        // instead of at every write site.
+        const normalized: PtyChunk =
+          data instanceof ArrayBuffer ? new Uint8Array(data) : (data as PtyChunk);
         const callback = get().ptyDataCallbacks[ptyId];
         if (callback) {
-          callback(data);
+          callback(normalized);
         } else {
           // Buffer data until the xterm callback is registered.
           // This happens when pty:restore response arrives before the
@@ -263,7 +277,7 @@ export const useTerminalStore = create<TerminalState>()(
             buf = [];
             pendingPtyData.set(ptyId, buf);
           }
-          buf.push(data);
+          buf.push(normalized);
         }
       },
 

--- a/packages/runtime/src/__tests__/services/pty-manager.test.ts
+++ b/packages/runtime/src/__tests__/services/pty-manager.test.ts
@@ -12,7 +12,7 @@
  *   4. Kill cleanup
  */
 
-import { describe, test, expect, beforeEach } from 'vitest';
+import { describe, test, expect, beforeEach, vi, afterEach } from 'vitest';
 
 // ── Scrollback ring buffer (extracted from pty-manager.ts) ──────────
 
@@ -599,5 +599,191 @@ describe('buildVenvActivateCommand', () => {
     expect(buildVenvActivateCommand('/path with spaces/.venv', 'bash')).toBe(
       `source '/path with spaces/.venv'/bin/activate && clear\r`,
     );
+  });
+});
+
+// ── Output coalescing (extracted from pty-manager.ts) ────────────────
+//
+// The production version wires onData → wsBroker through this same
+// state machine; here we extract it so the timer + size thresholds can
+// be tested deterministically without a real WebSocket.
+
+type FlushReason = 'size' | 'timer' | 'close';
+
+interface CoalesceBuf {
+  chunks: string[];
+  bytes: number;
+  chunkCount: number;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+class OutputCoalescer {
+  private buffers = new Map<string, CoalesceBuf>();
+
+  constructor(
+    private readonly flushBytes: number,
+    private readonly flushMs: number,
+    private readonly emit: (
+      ptyId: string,
+      data: string,
+      info: { reason: FlushReason; chunks: number; bytes: number },
+    ) => void,
+  ) {}
+
+  enqueue(ptyId: string, data: string): void {
+    let buf = this.buffers.get(ptyId);
+    if (!buf) {
+      buf = { chunks: [], bytes: 0, chunkCount: 0, timer: null };
+      this.buffers.set(ptyId, buf);
+    }
+    buf.chunks.push(data);
+    buf.bytes += data.length;
+    buf.chunkCount += 1;
+    if (buf.bytes >= this.flushBytes) {
+      this.flush(ptyId, 'size');
+      return;
+    }
+    if (!buf.timer) {
+      buf.timer = setTimeout(() => this.flush(ptyId, 'timer'), this.flushMs);
+    }
+  }
+
+  flush(ptyId: string, reason: FlushReason): void {
+    const buf = this.buffers.get(ptyId);
+    if (!buf || buf.chunks.length === 0) return;
+    if (buf.timer) {
+      clearTimeout(buf.timer);
+      buf.timer = null;
+    }
+    const data = buf.chunks.length === 1 ? buf.chunks[0] : buf.chunks.join('');
+    const chunkCount = buf.chunkCount;
+    const byteCount = buf.bytes;
+    this.buffers.delete(ptyId);
+    this.emit(ptyId, data, { reason, chunks: chunkCount, bytes: byteCount });
+  }
+
+  drop(ptyId: string): void {
+    const buf = this.buffers.get(ptyId);
+    if (!buf) return;
+    if (buf.timer) clearTimeout(buf.timer);
+    this.buffers.delete(ptyId);
+  }
+
+  flushAll(reason: FlushReason): void {
+    for (const ptyId of this.buffers.keys()) this.flush(ptyId, reason);
+  }
+
+  get pendingCount(): number {
+    return this.buffers.size;
+  }
+}
+
+describe('OutputCoalescer', () => {
+  type Emitted = {
+    ptyId: string;
+    data: string;
+    info: { reason: FlushReason; chunks: number; bytes: number };
+  };
+  let emitted: Emitted[];
+  let coalescer: OutputCoalescer;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    emitted = [];
+    coalescer = new OutputCoalescer(64, 8, (ptyId, data, info) => {
+      emitted.push({ ptyId, data, info });
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('enqueue under threshold and timer does not emit immediately', () => {
+    coalescer.enqueue('pty-1', 'hi');
+    expect(emitted).toHaveLength(0);
+  });
+
+  test('multiple small chunks coalesce into a single emit on timer', () => {
+    coalescer.enqueue('pty-1', 'hel');
+    coalescer.enqueue('pty-1', 'lo ');
+    coalescer.enqueue('pty-1', 'world');
+    expect(emitted).toHaveLength(0);
+
+    vi.advanceTimersByTime(8);
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].data).toBe('hello world');
+    expect(emitted[0].info.reason).toBe('timer');
+    expect(emitted[0].info.chunks).toBe(3);
+    expect(emitted[0].info.bytes).toBe(11);
+  });
+
+  test('reaching flushBytes triggers immediate size flush', () => {
+    // 64 byte threshold, push 70 in one call
+    coalescer.enqueue('pty-1', 'a'.repeat(70));
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].info.reason).toBe('size');
+    expect(emitted[0].data.length).toBe(70);
+  });
+
+  test('size flush after partial fill emits and resets', () => {
+    coalescer.enqueue('pty-1', 'a'.repeat(30));
+    coalescer.enqueue('pty-1', 'b'.repeat(40)); // total 70 ≥ 64
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].info.reason).toBe('size');
+    expect(emitted[0].info.chunks).toBe(2);
+    expect(emitted[0].data).toBe('a'.repeat(30) + 'b'.repeat(40));
+
+    // Buffer should be empty now — next chunk waits for the timer again
+    coalescer.enqueue('pty-1', 'next');
+    expect(emitted).toHaveLength(1);
+    vi.advanceTimersByTime(8);
+    expect(emitted).toHaveLength(2);
+    expect(emitted[1].data).toBe('next');
+  });
+
+  test('close flush drains pending data with reason=close', () => {
+    coalescer.enqueue('pty-1', 'final');
+    coalescer.flush('pty-1', 'close');
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].info.reason).toBe('close');
+    expect(emitted[0].data).toBe('final');
+  });
+
+  test('drop clears timer without emitting', () => {
+    coalescer.enqueue('pty-1', 'discarded');
+    coalescer.drop('pty-1');
+    vi.advanceTimersByTime(100);
+    expect(emitted).toHaveLength(0);
+    expect(coalescer.pendingCount).toBe(0);
+  });
+
+  test('flush on unknown ptyId is a no-op', () => {
+    coalescer.flush('nonexistent', 'close');
+    expect(emitted).toHaveLength(0);
+  });
+
+  test('per-pty isolation — flushing one does not flush another', () => {
+    coalescer.enqueue('pty-1', 'one');
+    coalescer.enqueue('pty-2', 'two');
+    coalescer.flush('pty-1', 'close');
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].ptyId).toBe('pty-1');
+    expect(coalescer.pendingCount).toBe(1);
+
+    vi.advanceTimersByTime(8);
+    expect(emitted).toHaveLength(2);
+    expect(emitted[1].ptyId).toBe('pty-2');
+    expect(emitted[1].data).toBe('two');
+  });
+
+  test('flushAll drains every pending buffer', () => {
+    coalescer.enqueue('pty-1', 'a');
+    coalescer.enqueue('pty-2', 'b');
+    coalescer.enqueue('pty-3', 'c');
+    coalescer.flushAll('close');
+    expect(emitted).toHaveLength(3);
+    expect(emitted.every((e) => e.info.reason === 'close')).toBe(true);
   });
 });

--- a/packages/runtime/src/__tests__/services/ws-broker.test.ts
+++ b/packages/runtime/src/__tests__/services/ws-broker.test.ts
@@ -296,4 +296,78 @@ describe('WSBroker', () => {
       expect(ws2.send).toHaveBeenCalledTimes(1);
     });
   });
+
+  // ───────────────────────── Binary pty:data ────────────────────────────
+  // The PTY → server hop sends raw bytes inside the event so Socket.IO
+  // emits a binary frame instead of JSON-escaping the string. The broker
+  // must (a) deliver the event to listeners untouched so the Uint8Array
+  // survives the hop, and (b) skip JSON.stringify entirely when no
+  // native clients are attached — otherwise Buffer.toJSON() blows up the
+  // payload size for the size guard.
+
+  describe('binary pty:data path', () => {
+    test('listener receives Uint8Array payload unmodified', () => {
+      const listener = vi.fn();
+      broker.onEvent(listener);
+
+      const bytes = new Uint8Array([0xc3, 0xa9, 0x0a]); // "é\n" UTF-8
+      const event = {
+        type: 'pty:data',
+        threadId: '',
+        data: { ptyId: 'p1', data: bytes },
+      } as any;
+
+      broker.emitToUser('user-X', event);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      const [delivered, deliveredUserId] = listener.mock.calls[0];
+      expect(deliveredUserId).toBe('user-X');
+      // Same Uint8Array reference reaches the forwarder — Socket.IO will
+      // then promote it to a binary attachment.
+      expect(delivered.data.data).toBe(bytes);
+      expect(delivered.data.data).toBeInstanceOf(Uint8Array);
+    });
+
+    test('no native clients → skips JSON.stringify entirely (fast path)', () => {
+      // The whole point of the fast path: with zero native clients we must
+      // NOT serialize, NOT call ws.send, NOT log a payload-size warning,
+      // and Buffer payloads must pass through without choking the guard.
+      const bytes = Buffer.alloc(2 * 1024 * 1024); // 2 MB binary payload
+      const event = {
+        type: 'pty:data',
+        threadId: '',
+        data: { ptyId: 'p1', data: bytes },
+      } as any;
+
+      const listener = vi.fn();
+      broker.onEvent(listener);
+
+      // Spy on JSON.stringify to make sure we don't run it.
+      const stringifySpy = vi.spyOn(JSON, 'stringify');
+      try {
+        broker.emitToUser('any-user', event);
+      } finally {
+        stringifySpy.mockRestore();
+      }
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(stringifySpy).not.toHaveBeenCalled();
+      // Size guard MUST NOT fire — Buffer.toJSON() expansion previously
+      // produced a megabyte-sized JSON array even for compact binary data,
+      // tripping the large/dropped warnings.
+      expect(log.warn).not.toHaveBeenCalled();
+    });
+
+    test('with native clients attached, sending still works (legacy path)', () => {
+      // Standalone mode still has the JSON path for any directly-attached
+      // ws. We only need to confirm the new fast-path bail does NOT
+      // silently swallow events when clients exist.
+      const ws = makeMockWs();
+      broker.addClient(ws, 'user-Z');
+
+      broker.emitToUser('user-Z', makeEvent('agent:message', 'thread-Z'));
+
+      expect(ws.send).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/runtime/src/services/pty-manager.ts
+++ b/packages/runtime/src/services/pty-manager.ts
@@ -185,9 +185,8 @@ function flushCoalesce(ptyId: string, reason: 'size' | 'timer' | 'close'): void 
     clearTimeout(buf.timer);
     buf.timer = null;
   }
-  const data = buf.chunks.length === 1 ? buf.chunks[0] : buf.chunks.join('');
+  const joined = buf.chunks.length === 1 ? buf.chunks[0] : buf.chunks.join('');
   const chunkCount = buf.chunkCount;
-  const byteCount = buf.bytes;
   // Free the empty buffer — a fresh chunk will recreate it on demand.
   coalesceBuffers.delete(ptyId);
 
@@ -198,15 +197,20 @@ function flushCoalesce(ptyId: string, reason: 'size' | 'timer' | 'close'): void 
     return;
   }
 
+  // Convert to a UTF-8 byte buffer so Socket.IO emits a binary frame
+  // (rather than JSON-escaping each byte). This is the biggest win for
+  // heavy stdout: no per-byte escape, no JSON.parse on the receiver.
+  const payload = Buffer.from(joined, 'utf8');
+
   wsBroker.emitToUser(session.userId, {
     type: 'pty:data' as const,
     threadId: '',
-    data: { ptyId, data },
+    data: { ptyId, data: payload },
   });
 
   metric('pty.flush', 1, { attributes: { reason } });
   recordHistogram('pty.flush_chunks', chunkCount);
-  recordHistogram('pty.flush_bytes', byteCount, { unit: 'By' });
+  recordHistogram('pty.flush_bytes', payload.byteLength, { unit: 'By' });
 }
 
 function enqueueCoalesce(ptyId: string, data: string): void {

--- a/packages/runtime/src/services/pty-manager.ts
+++ b/packages/runtime/src/services/pty-manager.ts
@@ -20,6 +20,7 @@ import { sql } from 'drizzle-orm';
 
 import { db, getConnection } from '../db/index.js';
 import { log } from '../lib/logger.js';
+import { metric, recordHistogram } from '../lib/telemetry.js';
 import type { PtyBackend } from './pty-backend.js';
 import { validateShellId } from './shell-detector.js';
 import { wsBroker } from './ws-broker.js';
@@ -152,6 +153,88 @@ function clearScrollback(ptyId: string): void {
   scrollbackSizes.delete(ptyId);
 }
 
+// ── PTY → WS output coalescing ───────────────────────────────────────
+// High-throughput shell output (e.g. `cat large`, `yes`, npm install) hits
+// the onData callback once per PTY read syscall — typically every few KB.
+// Each callback previously produced one full JSON-serialized WS frame, which
+// is the dominant CPU cost on the runtime under load. We coalesce contiguous
+// chunks into a single pty:data event:
+//   - flush when the buffered output reaches FLUSH_BYTES
+//   - otherwise flush after FLUSH_MS via a single timer
+//   - flush on session close (exit/error/kill) so no bytes are lost
+//
+// FLUSH_MS is intentionally small (≈120 Hz) so interactive echo latency
+// stays imperceptible while still aggregating during bursts.
+
+const FLUSH_BYTES = Number(process.env.PTY_FLUSH_BYTES) || 64 * 1024;
+const FLUSH_MS = Number(process.env.PTY_FLUSH_MS) || 8;
+
+interface CoalesceBuffer {
+  chunks: string[];
+  bytes: number;
+  chunkCount: number;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+const coalesceBuffers = new Map<string, CoalesceBuffer>();
+
+function flushCoalesce(ptyId: string, reason: 'size' | 'timer' | 'close'): void {
+  const buf = coalesceBuffers.get(ptyId);
+  if (!buf || buf.chunks.length === 0) return;
+  if (buf.timer) {
+    clearTimeout(buf.timer);
+    buf.timer = null;
+  }
+  const data = buf.chunks.length === 1 ? buf.chunks[0] : buf.chunks.join('');
+  const chunkCount = buf.chunkCount;
+  const byteCount = buf.bytes;
+  // Free the empty buffer — a fresh chunk will recreate it on demand.
+  coalesceBuffers.delete(ptyId);
+
+  const session = activeSessions.get(ptyId);
+  if (!session?.userId) {
+    // Session was already torn down — drop silently. Counters still recorded.
+    metric('pty.flush', 1, { attributes: { reason, dropped: 'true' } });
+    return;
+  }
+
+  wsBroker.emitToUser(session.userId, {
+    type: 'pty:data' as const,
+    threadId: '',
+    data: { ptyId, data },
+  });
+
+  metric('pty.flush', 1, { attributes: { reason } });
+  recordHistogram('pty.flush_chunks', chunkCount);
+  recordHistogram('pty.flush_bytes', byteCount, { unit: 'By' });
+}
+
+function enqueueCoalesce(ptyId: string, data: string): void {
+  let buf = coalesceBuffers.get(ptyId);
+  if (!buf) {
+    buf = { chunks: [], bytes: 0, chunkCount: 0, timer: null };
+    coalesceBuffers.set(ptyId, buf);
+  }
+  buf.chunks.push(data);
+  buf.bytes += data.length;
+  buf.chunkCount += 1;
+
+  if (buf.bytes >= FLUSH_BYTES) {
+    flushCoalesce(ptyId, 'size');
+    return;
+  }
+  if (!buf.timer) {
+    buf.timer = setTimeout(() => flushCoalesce(ptyId, 'timer'), FLUSH_MS);
+  }
+}
+
+function dropCoalesce(ptyId: string): void {
+  const buf = coalesceBuffers.get(ptyId);
+  if (!buf) return;
+  if (buf.timer) clearTimeout(buf.timer);
+  coalesceBuffers.delete(ptyId);
+}
+
 // ── Wire backend callbacks to WS broker ─────────────────────────────
 
 backend.init({
@@ -170,14 +253,15 @@ backend.init({
       });
       return;
     }
-    wsBroker.emitToUser(session.userId, {
-      type: 'pty:data' as const,
-      threadId: '',
-      data: { ptyId, data },
-    });
+    enqueueCoalesce(ptyId, data);
   },
 
   onExit(ptyId, exitCode) {
+    // Flush any pending output so the client renders the final bytes
+    // BEFORE seeing the exit event.
+    flushCoalesce(ptyId, 'close');
+    dropCoalesce(ptyId);
+
     const session = activeSessions.get(ptyId);
     log.info('PTY exited', { namespace: 'pty-manager', ptyId, exitCode });
 
@@ -226,6 +310,11 @@ backend.init({
     }
 
     log.error('PTY error', { namespace: 'pty-manager', ptyId, error });
+
+    // Flush any buffered output before the error event so we never lose
+    // the last bytes the PTY managed to produce.
+    flushCoalesce(ptyId, 'close');
+    dropCoalesce(ptyId);
 
     if (!session?.userId) {
       log.warn('PTY error for session without userId — dropping', {
@@ -497,6 +586,10 @@ export function signalPty(id: string, signal: number): void {
 
 export function killPty(id: string): void {
   log.info('Requesting kill PTY', { namespace: 'pty-manager', ptyId: id });
+  // Flush buffered output before tearing down so the client receives
+  // whatever the PTY had emitted just before the kill request.
+  flushCoalesce(id, 'close');
+  dropCoalesce(id);
   backend.kill(id);
   activeSessions.delete(id);
   clearScrollback(id);
@@ -507,6 +600,16 @@ export function killPty(id: string): void {
 }
 
 export function killAllPtys(): void {
+  // Snapshot the keys: flushCoalesce mutates coalesceBuffers as it drains.
+  for (const ptyId of [...coalesceBuffers.keys()]) {
+    flushCoalesce(ptyId, 'close');
+  }
+  // Any entries still present had no pending data — clear pending timers
+  // (none expected, but be defensive).
+  for (const buf of coalesceBuffers.values()) {
+    if (buf.timer) clearTimeout(buf.timer);
+  }
+  coalesceBuffers.clear();
   backend.killAll();
   activeSessions.clear();
   scrollbackBuffers.clear();

--- a/packages/runtime/src/services/ws-broker.ts
+++ b/packages/runtime/src/services/ws-broker.ts
@@ -156,6 +156,16 @@ class WSBroker {
   emitToUser(userId: string, event: WSEvent): void {
     this.notifyListeners(event, userId);
 
+    // In production runner mode the only consumer is the listener above
+    // (forwardEventToCentral → Socket.IO). Skip JSON.stringify entirely
+    // when no native clients are attached — saves CPU on the hot PTY path
+    // and avoids Buffer.toJSON() expanding binary pty:data payloads into
+    // {type:'Buffer',data:[…]} arrays for the size guard.
+    if (this.clients.size === 0) {
+      metric('ws.events', 1, { type: 'sum', attributes: { event: event.type, sent: '0' } });
+      return;
+    }
+
     const payload = JSON.stringify(event);
     if (!this.checkPayloadSize(payload, event)) return;
     const dead: ServerWebSocket<unknown>[] = [];

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -36,5 +36,8 @@
     "nanoid": "^5.1.5",
     "pg": "^8.20.0",
     "xstate": "^5.28.0"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.18.0"
   }
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -433,7 +433,14 @@ export interface WSAutomationRunCompletedData {
 
 export interface WSPtyDataData {
   ptyId: string;
-  data: string;
+  /**
+   * Terminal output bytes. The hot path (PTY → coalescer → WS) sends raw
+   * UTF-8 bytes as Uint8Array so Socket.IO uses a binary frame instead of
+   * JSON-escaping the string — this is the largest performance win for
+   * heavy stdout (npm install, cat, yes). String form is still accepted
+   * for restore/capture/adopt paths that don't go through the coalescer.
+   */
+  data: string | Uint8Array;
 }
 
 export interface WSPtyExitData {


### PR DESCRIPTION
The shared package imports `pg` in db/adapters/pg.ts but only relied on
hoisted @types/pg from runtime/server. After a clean bun install the
typecheck baseline fails with TS7016. Declaring it locally fixes resolution.